### PR TITLE
Reimplement CSemaphore using WaitOnAddress() for better contended performance

### DIFF
--- a/dev/ese/src/inc/_bf.hxx
+++ b/dev/ese/src/inc/_bf.hxx
@@ -359,7 +359,7 @@ C_ASSERT( sizeof( BF::bfbitfield ) == sizeof( FLAG32 ) );
 #ifdef _WIN64
 C_ASSERT( sizeof(BF) == 192 );
 #else
-C_ASSERT( sizeof(BF) == 160 );
+C_ASSERT( sizeof(BF) == 176 );
 #endif
 
 

--- a/dev/ese/src/inc/pib.hxx
+++ b/dev/ese/src/inc/pib.hxx
@@ -461,7 +461,7 @@ public:
 #ifdef _WIN64
 C_ASSERT( sizeof(PIB) == 608 );
 #else
-C_ASSERT( sizeof(PIB) == 504 );
+C_ASSERT( sizeof(PIB) == 528 );
 #endif
 
 INLINE SIZE_T OffsetOfTrxOldestILE()    { return OffsetOf( PIB, m_ileTrxOldest ); }

--- a/dev/ese/src/inc/tdb.hxx
+++ b/dev/ese/src/inc/tdb.hxx
@@ -432,7 +432,7 @@ class TDB
 #ifdef _AMD64_
         BYTE                m_bReserved2[8];
 #else
-        BYTE                m_bReserved2[4];
+
 #endif
 
 

--- a/dev/ese/src/sync/CMakeLists.txt
+++ b/dev/ese/src/sync/CMakeLists.txt
@@ -11,3 +11,7 @@ add_library(sync STATIC
 target_include_directories(sync PRIVATE
     ${INC_OUTPUT_DIRECTORY}/jet
 )
+
+target_link_libraries(sync
+    synchronization
+)


### PR DESCRIPTION
Some time ago I found out that ESE's write throughput is severely capped
by the number of concurrent writers.

The attached [`jet_concurrent_write_stall.zip`](https://github.com/microsoft/Extensible-Storage-Engine/files/6167563/jet_concurrent_write_stall.zip) example illustrates this.
Detailed benchmarks are below, but in short, all cases with more than 5
concurrent writers work even slower than a single writer.

Apparently, the throughput is limited by the current implementation of `CSemaphore`.
The existing implementation uses a spinlock that falls back to a — slow! —
kernel semaphore.  When the contention is high and cannot be alleviated by
the spinlock, this approach fails to deliver an adequate throughput.
`CSemaphore` is a building block for other primitives such as `CCriticalSection`,
which are in turn used in multiple performance-critical parts such as
[in the log buffer writer.](https://github.com/microsoft/Extensible-Storage-Engine/blob/da53c84053ac36fd34404511743c5dbbe24d0d5f/dev/ese/src/ese/_log/logwrite.cxx#L1056)

This PR reimplements `CSemaphore` using [`WaitOnAddress()`](https://docs.microsoft.com/windows/win32/api/synchapi/nf-synchapi-waitonaddress) / [`WakeByAddress()`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-wakebyaddresssingle)
as the underlying primitive.

The new implementation delivers an **up to 20x synthetic improvement.**
Since the `CSemaphore` is used as a building block for other synchronization
primitives, such as `CCriticalSection`, this translates into the **up to ~5.4x throughput**
improvement in a benchmark with multiple concurrent db writers.

The benchmarks below were conducted in an environment with an i9-9900K
CPU and an NVMe SSD.

Synthetic benchmark based on the adjusted semaphoreperf.cpp test:

    1 thread:    93850 KOps/Thread  →  93950 KOps/Thread
    2 threads:   20445 KOps/Thread  →  30165 KOps/Thread  (+48 %)
    3 threads:    6083 KOps/Thread  →  10897 KOps/Thread  (+79 %)
    8 threads:     102 KOps/Thread  →   2058 KOps/Thread  (+1917 %)
    16 threads:     45 KOps/Thread  →    719 KOps/Thread  (+1498 %)

Real benchmark with multiple concurrent db writers:

  (The numbers represent the amount of complete "write sequences"
   and are meaningful only as a relative measurement of throughput)

    1 writer:     8443 Sequences  →   8562 Sequences
    2 writers:   14934 Sequences  →  15331 Sequences
    3 writers:   17434 Sequences  →  17386 Sequences
    4 writers:   16583 Sequences  →  17997 Sequences
    5 writers:   15924 Sequences  →  17431 Sequences
    6 writers:    8437 Sequences  →  17223 Sequences  (+104 %)
    7 writers:    5020 Sequences  →  18145 Sequences  (+261 %)
    8 writers:    4131 Sequences  →  17670 Sequences  (+339 %)
    9 writers:    4168 Sequences  →  17438 Sequences  (+318 %)
    10 writers:   3670 Sequences  →  19709 Sequences  (+437 %)


The patch passes all relevant tests in my environment.
`CSemaphore` is thoroughly tested in [semaphore.cxx](https://github.com/microsoft/Extensible-Storage-Engine/blob/da53c84053ac36fd34404511743c5dbbe24d0d5f/test/ese/src/devlibtest/sync/syncunit/semaphore.cxx) and indirectly by various other tests.