### PR TITLE
CMakeLists: fix dependency on Microsoft-ETW-ESE.man

### DIFF
--- a/dev/ese/src/_etw/CMakeLists.txt
+++ b/dev/ese/src/_etw/CMakeLists.txt
@@ -17,7 +17,7 @@ add_custom_command(
         ${GEN_OUTPUT_DIRECTORY}/_etw/Microsoft-ETW-ESE.h
         ${GEN_OUTPUT_DIRECTORY}/_etw/Microsoft-ETW-ESE.rc
     COMMAND ${CMAKE_MESSAGE_COMPILER} -um ${GEN_OUTPUT_DIRECTORY}/_etw/Microsoft-ETW-ESE.man -h ${GEN_OUTPUT_DIRECTORY}/_etw -r ${GEN_OUTPUT_DIRECTORY}/_etw
-    DEPENDS ${MC_INPUT}
+    DEPENDS ${GEN_OUTPUT_DIRECTORY}/_etw/Microsoft-ETW-ESE.man
 )
 
 add_custom_target(gen_etw


### PR DESCRIPTION
The [CMakeLists.txt configuration](https://github.com/microsoft/Extensible-Storage-Engine/blob/da53c84053ac36fd34404511743c5dbbe24d0d5f/dev/ese/src/_etw/CMakeLists.txt#L20) in `src\_etw` specifies the non-existing
dependency when calling the message compiler for `Microsoft-ETW-ESE.man`.

This causes the following error during rebuild in my environment, most likely
due to an incorrect build order:

    Generating ../../../../gen/_etw/Microsoft-ETW-ESE.h, ../../../../gen/_etw/Microsoft-ETW-ESE.rc
    mc : error : 0x2 trying to open file <[...]/build/gen/_etw/Microsoft-ETW-ESE.man>.

This PR fixes it by making the command depend on `Microsoft-ETW-ESE.man`.