### PR TITLE
cpage_test.cxx: Fix build error caused by mismatching defines

### DIFF
--- a/dev/ese/src/ese/cpage_test.cxx
+++ b/dev/ese/src/ese/cpage_test.cxx
@@ -561,12 +561,12 @@ JETUNITTEST ( CPAGE, PageValidationBig )
     CHECK( pgno == validationaction.m_pgnoExpected );
     CHECK( ( 2 * pgno ) == validationaction.m_pgno );
 
-#ifdef DEBUG
+#ifndef RTM
     const bool fPreviouslySet = FNegTestSet( fCorruptingPagePgnos );
 #endif
     CHECK( cpage.PgnoThis() == ( 2 * pgno ) );
     CHECK( cpage.PgnoThis() != pgno );
-#ifdef DEBUG
+#ifndef RTM
     if ( !fPreviouslySet )
     {
         FNegTestUnset( fCorruptingPagePgnos );
@@ -575,11 +575,11 @@ JETUNITTEST ( CPAGE, PageValidationBig )
 
     cpage.SetPgno( pgno );
     pvBuffer[200] = ~pvBuffer[200];
-#ifdef DEBUG
+#ifndef RTM
     FNegTestSet( fCorruptingWithLostFlush );
 #endif
     CHECK( JET_errReadVerifyFailure == cpage.ErrValidatePage( pgvfDoNotCheckForLostFlush, &validationaction ) );
-#ifdef DEBUG
+#ifndef RTM
     FNegTestSet( fPreviouslySet );
 #endif
 


### PR DESCRIPTION
The `PageValidationBig()` test [uses #ifdef DEBUG and #ifndef RTM](https://github.com/microsoft/Extensible-Storage-Engine/blob/7bdead98c231c4fbb92d75ca8eb6ac1704e3ca3e/dev/ese/src/ese/cpage_test.cxx#L590) as if they
were interchangeable, but this is not so at least in the `RelWithDebInfo`
cmake configuration.

This currently causes the following errors when building the `RelWithDebInfo`
configuration:

    error C2065: 'fPreviouslySet': undeclared identifier

This PR fixes it by consistently using `#ifndef RTM`, as it's already being
used in the other similar tests in cpage_test.cxx.

(Perhaps, the `RelWithDebInfo` configuration could use the same defines
 as `Release`, but the code discrepancy seems to be worth fixing by itself.)