### PR TITLE
Handle redo operations on pages with dbtime revert in the required range after revert completes (VaKishan)

### DIFF
--- a/dev/ese/src/_res/jetmsg.mc
+++ b/dev/ese/src/_res/jetmsg.mc
@@ -1629,6 +1629,15 @@ Language=English
 Tag: %10%n
 .
 
+MessageId=565
+SymbolicName=RECOVERY_DATABASE_BAD_REVERTED_PAGE_ID
+Language=English
+%1 (%2) %3Database %4: Page %5 failed verification due to being reverted to a new page using revert snapshot, but the log record at log position %6 expected the page to not be a new page (currently replaying log position %7).  Recovery/restore will fail with error %8.  This problem is likely due to a bad revert operation.
+%nAdditional information:
+%n%tWithin initial required range: %9
+%n%tTotal number of pages affected: %10
+.
+
 
 ;// !!! ARE YOU SURE you're adding this in the right place !!! ???
 

--- a/dev/ese/src/ese/_log/logredomap.cxx
+++ b/dev/ese/src/ese/_log/logredomap.cxx
@@ -219,6 +219,11 @@ HandleError:
     CallSx( err, JET_errOutOfMemory );
 }
 
+VOID CLogRedoMap::ClearPgno( __in PGNO pgno )
+{
+    ClearPgno( pgno, pgno );
+}
+
 VOID CLogRedoMap::GetOldestLgposEntry( __out PGNO* const ppgno, __out RedoMapEntry* const prme, __out CPG* const pcpg ) const
 {
     Assert( FAnyPgnoSet() );

--- a/dev/ese/src/ese/bf.cxx
+++ b/dev/ese/src/ese/bf.cxx
@@ -21545,7 +21545,7 @@ ERR ErrBFIPrepareFlushPage(
         CPAGE cpage;
         Assert( CbBFIBufferSize( pbf ) == CbBFIPageSize( pbf ) );
         cpage.LoadPage( pbf->ifmp, pbf->pgno, pbf->pv, CbBFIBufferSize( pbf ) );
-        if ( !FBFIBufferIsZeroed( pbf ) && ( cpage.Dbtime() != dbtimeShrunk ) && ( cpage.Dbtime() != dbtimeRevert ) )
+        if ( !FBFIBufferIsZeroed( pbf ) && ( cpage.Dbtime() != dbtimeShrunk ) && !cpage.FRevertedNewPage() )
         {
             pgftPageCurrent = cpage.Pgft();
 
@@ -24444,7 +24444,7 @@ void BFISyncWriteComplete(  const ERR           err,
             Assert( cbBuffer == cbPage );
             cpage.LoadPage( pbf->ifmp, pbf->pgno, pbf->pv, cbBuffer );
             dbtime = cpage.Dbtime();
-            if ( !FUtilZeroed( (BYTE*)pbf->pv, cbBuffer ) && ( dbtime != dbtimeShrunk ) && ( dbtime != dbtimeRevert ) )
+            if ( !FUtilZeroed( (BYTE*)pbf->pv, cbBuffer ) && ( dbtime != dbtimeShrunk ) && !cpage.FRevertedNewPage() )
             {
                 pgft = cpage.Pgft();
             }
@@ -25263,7 +25263,7 @@ void BFIAsyncWriteComplete( const ERR           err,
             Assert( cbBuffer == cbPage );
             cpage.LoadPage( pbf->ifmp, pbf->pgno, pbf->pv, cbBuffer );
             dbtime = cpage.Dbtime();
-            if ( !FUtilZeroed( (BYTE*)pbf->pv, cbBuffer ) && ( dbtime != dbtimeShrunk ) && ( dbtime != dbtimeRevert ) )
+            if ( !FUtilZeroed( (BYTE*)pbf->pv, cbBuffer ) && ( dbtime != dbtimeShrunk ) && !cpage.FRevertedNewPage() )
             {
                 pgft = cpage.Pgft();
             }

--- a/dev/ese/src/ese/cpage.cxx
+++ b/dev/ese/src/ese/cpage.cxx
@@ -3544,6 +3544,12 @@ BOOL CPAGE::FShrunkPage ( ) const
     return dbtimeShrunk == Dbtime();
 }
 
+//  ================================================================
+BOOL CPAGE::FRevertedNewPage ( ) const
+//  ================================================================
+{
+    return CPAGE::FRevertedNewPage( Dbtime() );
+}
 
 //  ================================================================
 VOID CPAGE::ResetAllFlags( INT fFlags )

--- a/dev/ese/src/ese/db.cxx
+++ b/dev/ese/src/ese/db.cxx
@@ -3989,7 +3989,7 @@ ERR ISAMAPI ErrIsamAttachDatabase(
 
             pfmp = &g_rgfmp[ ifmp ];
 
-            Assert( ( pfmp->PLogRedoMapZeroed() == NULL ) && ( pfmp->PLogRedoMapBadDbTime() == NULL ) );
+            Assert( ( pfmp->PLogRedoMapZeroed() == NULL ) && ( pfmp->PLogRedoMapBadDbTime() == NULL ) && ( pfmp->PLogRedoMapDbtimeRevert() == NULL ) );
 
             Assert( !pinst->FRecovering() );
             Assert( !pfmp->FReadOnlyAttach() && !g_fRepair );
@@ -4286,7 +4286,7 @@ ERR ISAMAPI ErrIsamAttachDatabase(
     Call( ErrDBReadHeaderCheckConsistency( pfsapi, pfmp ) );
     pfmp->TraceDbfilehdrInfo( tsidrEngineFmpDbHdr1st );
 
-    Assert( ( pfmp->PLogRedoMapZeroed() == NULL ) && ( pfmp->PLogRedoMapBadDbTime() == NULL ) );
+    Assert( ( pfmp->PLogRedoMapZeroed() == NULL ) && ( pfmp->PLogRedoMapBadDbTime() == NULL ) && ( pfmp->PLogRedoMapDbtimeRevert() == NULL ) );
 
     if ( !plog->FLogDisabled()
         && 0 == memcmp( &pfmp->Pdbfilehdr()->signLog, &plog->SignLog(), sizeof(SIGNATURE) ) )

--- a/dev/ese/src/ese/flushmap.cxx
+++ b/dev/ese/src/ese/flushmap.cxx
@@ -2252,12 +2252,12 @@ ERR CFlushMap::ErrSetRangePgnoFlushType_( const PGNO pgnoFirst, const CPG cpg, c
         Assert( pfmd->sxwl.FNotOwner() );
         pfmd->sxwl.AcquireSharedLatch();
 
-        const BOOL fValidDbTime = ( ( dbtime != dbtimeNil ) && ( dbtime != dbtimeInvalid ) && ( dbtime != dbtimeShrunk ) && ( dbtime > 0 ) && ( dbtime != dbtimeRevert ) );
+        const BOOL fValidDbTime = ( ( dbtime != dbtimeNil ) && ( dbtime != dbtimeInvalid ) && ( dbtime != dbtimeShrunk ) && ( dbtime > 0 ) && !CPAGE::FRevertedNewPage( dbtime ) );
         Expected( fValidDbTime ||
-            ( dbtime == dbtimeNil ) ||      // used whenever the true dbtime can't be obtained.
-            ( dbtime == 0 ) ||              // uninitialized pages.
-            ( dbtime == dbtimeShrunk ) ||   // beyond EOF pages referenced in recovery are initialized with dbtimeShrunk.
-            ( dbtime == dbtimeRevert ) );   // Page which was reverted to a new page by RBS.
+            ( dbtime == dbtimeNil ) ||              // used whenever the true dbtime can't be obtained.
+            ( dbtime == 0 ) ||                      // uninitialized pages.
+            ( dbtime == dbtimeShrunk ) ||           // beyond EOF pages referenced in recovery are initialized with dbtimeShrunk.
+            CPAGE::FRevertedNewPage( dbtime ) );    // Page which was reverted to a new page by RBS.
 
 #ifndef ENABLE_JET_UNIT_TEST
         // Real code (i.e., not unit tests) should not be setting valid flush types on ranges.

--- a/dev/ese/src/inc/_logredomap.hxx
+++ b/dev/ese/src/inc/_logredomap.hxx
@@ -74,5 +74,6 @@ class CLogRedoMap
             __in const DBTIME dbtimePage,
             __in const DBTIME dbtimeAfter );
         VOID ClearPgno( __in PGNO pgnoStart, __in PGNO pgnoEnd );
+        VOID ClearPgno( __in PGNO pgno );
         VOID GetOldestLgposEntry( __out PGNO* const ppgno, __out RedoMapEntry* const prme, __out CPG* const pcpg ) const;
 };

--- a/dev/ese/src/inc/cpage.hxx
+++ b/dev/ese/src/inc/cpage.hxx
@@ -369,7 +369,10 @@ class CPAGE
         BOOL    FNewChecksumFormat  ( ) const;
         BOOL    FLastNodeHasNullKey( ) const;
 
-        BOOL    FShrunkPage ( ) const;
+        BOOL        FShrunkPage         ( ) const;
+        BOOL        FRevertedNewPage    ( ) const;
+        static BOOL FRevertedNewPage    ( const DBTIME dbtime ) { return dbtimeRevert == dbtime; }
+
         enum PageFlushType;
         PageFlushType Pgft      ( ) const;
 

--- a/dev/ese/src/inc/fmp.hxx
+++ b/dev/ese/src/inc/fmp.hxx
@@ -484,6 +484,12 @@ class FMP
         // The above gets hit occasionally when running `accept nocopy dml onetest forever`.
         CLogRedoMap *       m_pLogRedoMapBadDbtime;
 
+        // Keeps track of which pages have a dbtime equal to dbtimerevert
+        // dbtimerevert indicates a page which was reverted back to a new page using revert snapshot.
+        // This implies that there is a log record later in the required range which frees up 
+        // this erroneous page.
+        CLogRedoMap *       m_pLogRedoMapDbtimeRevert;
+
     // =====================================================================
     // Member retrieval..
     public:
@@ -675,6 +681,7 @@ public:
         //
         CLogRedoMap* PLogRedoMapZeroed() const        { return m_pLogRedoMapZeroed; };
         CLogRedoMap* PLogRedoMapBadDbTime() const     { return m_pLogRedoMapBadDbtime; };
+        CLogRedoMap* PLogRedoMapDbtimeRevert() const  { return m_pLogRedoMapDbtimeRevert; };
 
     // =====================================================================
     // Member manipulation.
@@ -1116,6 +1123,8 @@ public:
     }
 
     ERR ErrPgnoLastFileSystem( PGNO* const ppgnoLast ) const;
+
+    BOOL FPgnoInZeroedOrRevertedMaps( const PGNO pgno ) const;
 
     friend DBFILEHDR * PdbfilehdrEDBGAccessor( const FMP * const pfmp );
 

--- a/dev/ese/src/os/edbg.cxx
+++ b/dev/ese/src/os/edbg.cxx
@@ -18214,6 +18214,7 @@ VOID FMP::Dump( CPRINTF * pcprintf, DWORD_PTR dwOffset ) const
     (*pcprintf)( FORMAT_VOID( FMP, this, m_sxwlRedoMaps, dwOffset ) );
     (*pcprintf)( FORMAT_POINTER( FMP, this, m_pLogRedoMapZeroed, dwOffset ) );
     (*pcprintf)( FORMAT_POINTER( FMP, this, m_pLogRedoMapBadDbtime, dwOffset ) );
+    (*pcprintf)( FORMAT_POINTER( FMP, this, m_pLogRedoMapDbtimeRevert, dwOffset ) );
 }
 
 INLINE ERR CHECKPOINT::Dump( CPRINTF* pcprintf, DWORD_PTR dwOffset ) const


### PR DESCRIPTION
1. Add a new redomap which captures redo operations on pages with time dbtimerevert.
2. Remove the page from the redomap if page is freed as part of lrtypMerge, lrtypExtentFreed, lrtypEmptyTree, lrtypPageMove
3. Add separate event for pages still in the redomap at the end of redo.
4. Add test to see if we still hit the corruption.

from: f720eaba3fb9959079e30c68cf55e9b380857b7b
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/Extensible-Storage-Engine/pull/38)