### PR TITLE
Add ability to pause OLD tasks to alleviate pressure on copy queues

### DIFF
--- a/dev/ese/src/ese/fmp.cxx
+++ b/dev/ese/src/ese/fmp.cxx
@@ -2964,6 +2964,20 @@ ERR FMP::FPgnoInZeroedOrRevertedMaps( const PGNO pgno ) const
            ( PLogRedoMapDbtimeRevert() && PLogRedoMapDbtimeRevert()->FPgnoSet( pgno ) );
 }
 
+//  ================================================================
+VOID FMP::PauseOLD2Tasks()
+//  ================================================================
+{
+    OLD2PauseTasks();
+}
+
+//  ================================================================
+VOID FMP::UnpauseOLD2Tasks()
+//  ================================================================
+{
+    OLD2UnpauseTasks();
+}
+
 #ifdef ENABLE_JET_UNIT_TEST
 
 // these are used by testing routines that need a mock FMP

--- a/dev/ese/src/ese/jetapi.cxx
+++ b/dev/ese/src/ese/jetapi.cxx
@@ -22223,7 +22223,7 @@ JET_ERR JET_API JetStopServiceInstanceEx( __in JET_INSTANCE instance, _In_ JET_G
                     pfmpCurr = &g_rgfmp[ifmp];
                     pfmpCurr->RwlDetaching().EnterAsReader();
 
-                    pfmpCurr->ResetFDontRegisterOLD2Tasks();
+                    pfmpCurr->UnpauseOLD2Tasks();
 
                     pfmpCurr->RwlDetaching().LeaveAsReader();
                     pfmpCurr = NULL;
@@ -22308,7 +22308,9 @@ JET_ERR JET_API JetStopServiceInstanceEx( __in JET_INSTANCE instance, _In_ JET_G
                     pfmpCurr = &g_rgfmp[ifmp];
                     pfmpCurr->RwlDetaching().EnterAsReader();
 
-                    pfmpCurr->SetFDontRegisterOLD2Tasks();
+                    // Pauses execution of OLD tasks but allows
+                    // tasks to be registered for future processing
+                    pfmpCurr->PauseOLD2Tasks();
 
                     pfmpCurr->RwlDetaching().LeaveAsReader();
                     pfmpCurr = NULL;

--- a/dev/ese/src/inc/daeconst.hxx
+++ b/dev/ese/src/inc/daeconst.hxx
@@ -325,6 +325,7 @@ const INT rankBFLgposModifyHist         = 65;
 const INT rankBFFMPContext              = 66;
 const INT rankBFLRUK                    = 70;
 const INT rankRBSWrite                  = 70;
+const INT rankDefragPauseManager        = 70;
 const INT rankFMPDetaching              = 75;
 const INT rankFMPGlobal                 = 80;
 const INT rankSysParamFixup             = 85;

--- a/dev/ese/src/inc/fmp.hxx
+++ b/dev/ese/src/inc/fmp.hxx
@@ -861,6 +861,9 @@ public:
         BOOL FHardRecovery( const DBFILEHDR* const pdbfilehdr ) const;
         BOOL FHardRecovery() const;
 
+        VOID PauseOLD2Tasks();
+        VOID UnpauseOLD2Tasks();
+
 
     // =====================================================================
     // Physical File I/O Conversions

--- a/dev/ese/src/inc/old.hxx
+++ b/dev/ese/src/inc/old.hxx
@@ -511,3 +511,6 @@ ERR     ErrOLDDefragment(
 ERR ErrOLDInit();
 VOID OLDTerm();
 
+VOID OLD2PauseTasks();
+VOID OLD2UnpauseTasks();
+


### PR DESCRIPTION
When the user requests ESE to pause OLD2 tasks, this just sets the maxTasks to 0 so no new tasks can be run, but fragmented tables will still get added to the table for future processing.

[Substrate:10912ad682ecd38b9fd1f5f168a82141e4756fa6]