### PR TITLE
OSSTEST: Drop the all tests >= ~4 seconds (happens to be top 10 most expensive tests) temporarily.

### DIFF
--- a/test/ese/src/devlibtest/oslayer/oslayerunit/IoStatsSuite.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/IoStatsSuite.cxx
@@ -43,7 +43,7 @@ void PrintStatsBasicPercentages_( _In_ CIoStats * piostats, CHAR * szPiostatsNam
 //
 
 //  ================================================================
-CUnitTest( IoStatsBasicAcceptsAllValues, 0x0, "Tests that Io latency histograms can accept all values" );
+CUnitTest( IoStatsBasicAcceptsAllValues, bitExplicitOnly, "Tests that Io latency histograms can accept all values" );
 ERR IoStatsBasicAcceptsAllValues::ErrTest()
 //  ================================================================
 {

--- a/test/ese/src/devlibtest/oslayer/oslayerunit/mathtest.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/mathtest.cxx
@@ -242,7 +242,8 @@ ERR MathTest::ErrTest()
     OSTestCall( ErrFPowerOf2() );
     OSTestCall( ErrLog2() );
     OSTestCall( ErrLNextPowerOf2() );
-    OSTestCall( ErrHalfAvalancheHash() );
+    // FUTURE[SOMEONE] Revert when merge conflict for explicit test comes along.
+    //OSTestCall( ErrHalfAvalancheHash() );
 
 HandleError:
     if ( err )

--- a/test/ese/src/devlibtest/oslayer/oslayerunit/memorytest.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/memorytest.cxx
@@ -1391,7 +1391,7 @@ HandleError:
 //  Need to be deleted at the end
 extern CSparseBitmap*   psbm;
 
-CUnitTest( OSLayerResidentMapPerf, 0, "Tests performance of OSLayer residence map scan APIs" );
+CUnitTest( OSLayerResidentMapPerf, bitExplicitOnly, "Tests performance of OSLayer residence map scan APIs" );
 ERR OSLayerResidentMapPerf::ErrTest()
 {
     ERR err = JET_errSuccess;

--- a/test/ese/src/devlibtest/oslayer/oslayerunit/timerqueuetest.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/timerqueuetest.cxx
@@ -772,7 +772,7 @@ HandleError:
     return fSuccess;
 }
 
-CUnitTest( OSTimerTaskTestPeriodicEmulation, 0, "Tests that a timer task that regularly reschedules gets approximate periodic callbacks of right frequency." );
+CUnitTest( OSTimerTaskTestPeriodicEmulation, bitExplicitOnly, "Tests that a timer task that regularly reschedules gets approximate periodic callbacks of right frequency." );
 ERR OSTimerTaskTestPeriodicEmulation::ErrTest()
 {
     CSemaphore semTimerShot( CSyncBasicInfo( "PeriodicTimer" ) );
@@ -805,7 +805,7 @@ HandleError:
     return err;
 }
 
-CUnitTest( OSTimerTaskTestPeriodicEmulationWithInitial, 0, "Tests that a timer task that regularly reschedules gets approximate periodic callbacks of right frequency, and with an initial backoff." );
+CUnitTest( OSTimerTaskTestPeriodicEmulationWithInitial, bitExplicitOnly, "Tests that a timer task that regularly reschedules gets approximate periodic callbacks of right frequency, and with an initial backoff." );
 ERR OSTimerTaskTestPeriodicEmulationWithInitial::ErrTest()
 {
     CSemaphore semTimerShot( CSyncBasicInfo( "PeriodicTimer" ) );
@@ -838,7 +838,7 @@ HandleError:
     return err;
 }
 
-CUnitTest( OSTimerTaskTestOneShotWithExternalReschedule, 0, "Tests that a one-shot timer that gets repeatedly rescheduled (but not cancelled) only runs once after the last reschedule." );
+CUnitTest( OSTimerTaskTestOneShotWithExternalReschedule, bitExplicitOnly, "Tests that a one-shot timer that gets repeatedly rescheduled (but not cancelled) only runs once after the last reschedule." );
 ERR OSTimerTaskTestOneShotWithExternalReschedule::ErrTest()
 {
     CSemaphore semTimerShot( CSyncBasicInfo( "OneShotTimer" ) );
@@ -1718,7 +1718,7 @@ HandleError:
     return err;
 }
 
-CUnitTest( OSTimerTaskSchedulingTimerStress, 0, "SchedulingTimerStress." );
+CUnitTest( OSTimerTaskSchedulingTimerStress, bitExplicitOnly, "SchedulingTimerStress." );
 ERR OSTimerTaskSchedulingTimerStress::ErrTest()
 {
     printf( "\t%s\n", __FUNCTION__ );
@@ -1731,7 +1731,7 @@ ERR OSTimerTaskSchedulingTimerStress::ErrTest()
     return err;
 }
 
-CUnitTest( OSTimerTaskSelfSchedulingTimerStress, 0, "OSTimerTaskSelfSchedulingTimerStress." );
+CUnitTest( OSTimerTaskSelfSchedulingTimerStress, bitExplicitOnly, "OSTimerTaskSelfSchedulingTimerStress." );
 ERR OSTimerTaskSelfSchedulingTimerStress::ErrTest()
 {
     printf( "\t%s\n", __FUNCTION__ );

--- a/test/ese/src/devlibtest/oslayer/oslayerunit/timetest.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/timetest.cxx
@@ -89,7 +89,7 @@ HandleError:
     return err;
 }
 
-CUnitTest( OslayerHrtCheckPerfErrHrtHRTCountPerf, 0, "Loop to check ErrHrtHRTCount() perf." );
+CUnitTest( OslayerHrtCheckPerfErrHrtHRTCountPerf, bitExplicitOnly, "Loop to check ErrHrtHRTCount() perf." );
 ERR OslayerHrtCheckPerfErrHrtHRTCountPerf::ErrTest()
 {
     JET_ERR err = JET_errSuccess;

--- a/test/ese/src/devlibtest/sync/syncunit/semaphoreperf.cxx
+++ b/test/ese/src/devlibtest/sync/syncunit/semaphoreperf.cxx
@@ -689,6 +689,7 @@ class CSemaphorePerfTest : public UNITTEST
     protected:
         CSemaphorePerfTest()
         {
+            m_btcf = bitExplicitOnly;
         }
 
     public:


### PR DESCRIPTION
We have many many changes to sync for the last 4 years of catch-up and the test-script loop body is quite a factor in getting this done.  So this is a temporary necessity to accelerate GitHub syncing.  We will remove this when 'caught up' in some fashion.

Reduces OSS test pass from 5:02 minutes to ~:39 seconds.

Note: This change is back-dated to fit within the order of the filled in historical commits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/Extensible-Storage-Engine/pull/45)