### PR TITLE
Fix assorted correctness bugs found via a code-review sweep

### DIFF
--- a/dev/ese/published/inc/stat.hxx
+++ b/dev/ese/published/inc/stat.hxx
@@ -775,7 +775,7 @@ public:
         {
             return ERR::wrnOutOfSamples;
         }
-        else if ( m_iValueLastQuery > 1 &&
+        else if ( m_iValueLastQuery > 0 &&
                     qwValue < m_pValues[m_iValueLastQuery-1] )
         {
             return ERR::errInvalidParameter;
@@ -1276,7 +1276,7 @@ class CSegmentedHistogram : public CStats {
             {
                 return ERR::wrnOutOfSamples;
             }
-            else if ( m_iValueLastQuery > 1 &&
+            else if ( m_iValueLastQuery > 0 &&
                         qwValue < m_pValues[m_iValueLastQuery-1] )
             {
                 return ERR::errInvalidParameter;

--- a/dev/ese/src/_xpress9/Xpress9DecLz77.c
+++ b/dev/ese/src/_xpress9/Xpress9DecLz77.c
@@ -1045,8 +1045,8 @@ Xpress9DecoderFetchDecompressedData (
                     "Buffer too small to DirectDecode, uBytesNeeded=%Iu, uBytesToCopy=%Iu, uDecodePosition=%Iu, uBufferDataSize=%Iu",
                     uBytesNeeded,
                     uBytesToCopy,
-                    pDecoder->m_DecodeData.m_uDecodePosition
-                    pDecoder->m_BufferData.m_uBufferDataSize,
+                    pDecoder->m_DecodeData.m_uDecodePosition,
+                    pDecoder->m_BufferData.m_uBufferDataSize
                 );
                 goto Failure;
             }

--- a/dev/ese/src/ese/_log/logread.cxx
+++ b/dev/ese/src/ese/_log/logread.cxx
@@ -1071,8 +1071,16 @@ LOG_VERIFY_STATE::ErrVerifyHeader( INST * pinst, IFileAPI * pfapi, __deref_in_bc
     {
         m_state = LogVerifyLogSegments;
         m_cbSeg = plgfilehdr->lgfilehdr.le_cbSec;
-        *ppb += plgfilehdr->lgfilehdr.le_csecHeader * m_cbSeg;
-        *pcb -= plgfilehdr->lgfilehdr.le_csecHeader * m_cbSeg;
+        //  le_cbSec / le_csecHeader are persisted (untrusted) header fields; a zero sector size or a
+        //  header span larger than the buffer would underflow *pcb and walk past the buffer in
+        //  ErrVerifyLogSegments below.
+        const QWORD cbHeaderSpan = (QWORD)plgfilehdr->lgfilehdr.le_csecHeader * m_cbSeg;
+        if ( m_cbSeg == 0 || cbHeaderSpan > *pcb )
+        {
+            Error( ErrERRCheck( JET_errLogReadVerifyFailure ) );
+        }
+        *ppb += (DWORD)cbHeaderSpan;
+        *pcb -= (DWORD)cbHeaderSpan;
         m_iSeg = plgfilehdr->lgfilehdr.le_csecHeader;
     }
 
@@ -2337,8 +2345,11 @@ ERR LOG_READ_BUFFER::ErrLGIGetRecordAtPbNext( BYTE **ppbLR, BOOL fPreread, BOOL 
                     Error( ErrERRCheck( JET_errLogFileCorrupt ) );
                 }
                 else if ( CbLGFixedSizeOfRec( (LR *)pbCurrent ) > (DWORD)( pbSegment + m_pLogStream->CbSec() - pbCurrent ) ||
-                        CbLGSizeOfRec( (LR *)pbCurrent ) > (DWORD)( pbSegment + m_pLogStream->CbSec() - pbCurrent ) )
+                        CbLGSizeOfRec( (LR *)pbCurrent ) > (DWORD)( pbSegment + m_pLogStream->CbSec() - pbCurrent ) ||
+                        0 == CbLGSizeOfRec( (LR *)pbCurrent ) )
                 {
+                    //  a zero-size record (e.g. an obsolete/unknown in-range lrtyp) would not advance
+                    //  pbCurrent below, causing the caller to loop forever -- treat it as corruption.
                     AssertSz( FNegTest( fCorruptingLogFiles ), "Corrupt size of LR (%d,%d) past rest of segment (%d).",
                                     CbLGFixedSizeOfRec( (LR *)pbCurrent ),
                                     CbLGSizeOfRec( (LR *)pbCurrent ),

--- a/dev/ese/src/ese/_log/logredo.cxx
+++ b/dev/ese/src/ese/_log/logredo.cxx
@@ -237,6 +237,14 @@ LOCAL ERR ErrReplacePageImageHeaderTrailer(
                                 const DBTIME dbtimeBefore )
 {
 
+    //  cbHeader/cbTrailer come from a persisted (possibly corrupt) log record; reject a record
+    //  that would overrun the g_cbPage rebuild buffer (and underflow the memset in
+    //  RebuildPageImageHeaderTrailer) before touching the buffer.
+    if ( cbHeader < 0 || cbTrailer < 0 || cbHeader > g_cbPage || cbTrailer > g_cbPage || cbHeader + cbTrailer > g_cbPage )
+    {
+        return ErrERRCheck( JET_errLogFileCorrupt );
+    }
+
     VOID * pvBuffer;
     BFAlloc( bfasTemporary, &pvBuffer );
 
@@ -8076,6 +8084,13 @@ ERR LOG::ErrLGRIRedoInitializeSplit( PIB * const ppib, const LRSPLIT_ * const pl
     {
         const INT   cbKeyParent = plrsplit->le_cbKeyParent;
 
+        //  cbKeyParent is from a persisted (possibly corrupt) log record; bound it to the
+        //  RESBOOKMARK buffer capacity before copying to avoid a heap overflow.
+        if ( cbKeyParent > cbBookmarkAlloc )
+        {
+            Error( ErrERRCheck( JET_errLogCorrupted ) );
+        }
+
         psplit->kdfParent.key.suffix.SetPv( RESBOOKMARK.PvRESAlloc() );
         Alloc( psplit->kdfParent.key.suffix.Pv() );
 
@@ -8093,6 +8108,13 @@ ERR LOG::ErrLGRIRedoInitializeSplit( PIB * const ppib, const LRSPLIT_ * const pl
     {
         const INT   cbPrefix = plrsplit->le_cbPrefixSplitOld;
 
+        //  cbPrefix is from a persisted (possibly corrupt) log record; bound it to the
+        //  RESBOOKMARK buffer capacity before copying to avoid a heap overflow.
+        if ( cbPrefix > cbBookmarkAlloc )
+        {
+            Error( ErrERRCheck( JET_errLogCorrupted ) );
+        }
+
         psplit->prefixSplitOld.SetPv( RESBOOKMARK.PvRESAlloc() );
         Alloc( psplit->prefixSplitOld.Pv() );
 
@@ -8106,6 +8128,13 @@ ERR LOG::ErrLGRIRedoInitializeSplit( PIB * const ppib, const LRSPLIT_ * const pl
     if ( plrsplit->le_cbPrefixSplitNew > 0 )
     {
         const INT   cbPrefix = plrsplit->le_cbPrefixSplitNew;
+
+        //  cbPrefix is from a persisted (possibly corrupt) log record; bound it to the
+        //  RESBOOKMARK buffer capacity before copying to avoid a heap overflow.
+        if ( cbPrefix > cbBookmarkAlloc )
+        {
+            Error( ErrERRCheck( JET_errLogCorrupted ) );
+        }
 
         psplit->prefixSplitNew.SetPv( RESBOOKMARK.PvRESAlloc() );
         Alloc( psplit->prefixSplitNew.Pv() );
@@ -8460,6 +8489,13 @@ ERR LOG::ErrLGRIRedoInitializeMerge( PIB            *ppib,
     if ( plrmerge->le_cbKeyParentSep > 0 )
     {
         const INT   cbKeyParentSep = plrmerge->le_cbKeyParentSep;
+
+        //  cbKeyParentSep is from a persisted (possibly corrupt) log record; bound it to the
+        //  RESBOOKMARK buffer capacity before copying to avoid a heap overflow.
+        if ( cbKeyParentSep > cbBookmarkAlloc )
+        {
+            Error( ErrERRCheck( JET_errLogCorrupted ) );
+        }
 
         pmerge->kdfParentSep.key.suffix.SetPv( RESBOOKMARK.PvRESAlloc() );
         Alloc( pmerge->kdfParentSep.key.suffix.Pv() );
@@ -10590,8 +10626,12 @@ ERR LOG::ErrLGIRedoRootMoveStructures( PIB* const ppib, const DBTIME dbtime, ROO
 
                     // Copy new data.
                     const USHORT cbData = plrseh->CbData();
-                    Assert( cbData == sizeof( prmc->sphNew ) );
-                    Assert( cbData == prmc->dataSphNew.Cb() );
+                    //  cbData is from a persisted (possibly corrupt) log record; the destination
+                    //  is a fixed-size SPACE_HEADER, so reject a mismatched length.
+                    if ( cbData != sizeof( prmc->sphNew ) )
+                    {
+                        Error( ErrERRCheck( JET_errLogCorrupted ) );
+                    }
                     UtilMemCpy( prmc->dataSphNew.Pv(), plrseh->rgbData, cbData );
                 }
             }

--- a/dev/ese/src/ese/_log/logwrite.cxx
+++ b/dev/ese/src/ese/_log/logwrite.cxx
@@ -431,8 +431,8 @@ ERR LOG_BUFFER::InitCommit( LONG cBytes )
     {
         Error( ErrERRCheck( JET_errOutOfMemory ) );
     }
-    Assert( _pbLGCommitStart = _pbLGBufMin );
-    Assert( _pbLGCommitEnd = _pbLGBufMin + roundup( cBytes, OSMemoryPageCommitGranularity() ) - 1 );
+    Assert( _pbLGCommitStart == _pbLGBufMin );
+    Assert( _pbLGCommitEnd == _pbLGBufMin + roundup( cBytes, OSMemoryPageCommitGranularity() ) - 1 );
 
 HandleError:
     return err;

--- a/dev/ese/src/ese/_log/rstmap.cxx
+++ b/dev/ese/src/ese/_log/rstmap.cxx
@@ -939,7 +939,7 @@ BOOL LOG::FRstmapCheckDuplicateSignature(  )
 
         for ( irstmapSearch = irstmap + 1; irstmapSearch < m_irstmapMac; irstmapSearch++ )
         {
-            if ( !m_rgrstmap[irstmap].wszNewDatabaseName )
+            if ( !m_rgrstmap[irstmapSearch].wszNewDatabaseName )
                 continue;
 
             if ( 0 == memcmp(   &m_rgrstmap[irstmap].signDatabase,

--- a/dev/ese/src/ese/backup.cxx
+++ b/dev/ese/src/ese/backup.cxx
@@ -1198,7 +1198,10 @@ ERR BACKUP_CONTEXT::ErrBKIPrepareDirectory(
             {
                 Call( ErrERRCheck( JET_errInvalidPath ) );
             }
-            OSStrCbCopyW( wszBackupPath, cbBackupPath, wszAtomicOld );
+            //  append the "old" subdirectory onto the (already normalized) base backup path rather
+            //  than overwriting it -- the length check above sums both lengths, and the full-backup
+            //  branch below likewise appends its subdirectory.
+            OSStrCbAppendW( wszBackupPath, cbBackupPath, wszAtomicOld );
             CallS( m_pinst->m_pfsapi->ErrPathFolderNorm( wszBackupPath, cbBackupPath ) );
         }
         else

--- a/dev/ese/src/ese/cat.cxx
+++ b/dev/ese/src/ese/cat.cxx
@@ -15402,9 +15402,17 @@ ERR ErrCATGetNextRootObject(
     {
         // Retrieve the object name.
         Call( ErrRECIRetrieveVarColumn( pfcbNil, pfucbCatalog->u.pfcb->Ptdb(), fidMSO_Name, pfucbCatalog->kdfCurr.data, &dataField ) );
-        Assert( ( dataField.Cb() / sizeof( szObjectNameT[ 0 ] ) ) < _countof( szObjectNameT ) );
-        UtilMemCpy( szObjectNameT, dataField.Pv(), dataField.Cb() );
-        szObjectNameT[ dataField.Cb() / sizeof( szObjectNameT[0] ) ] = '\0';
+        const INT cbObjectName = dataField.Cb();
+        if ( cbObjectName < 0 || cbObjectName > JET_cbNameMost )
+        {
+            //  the persisted name length is untrusted; reject a corrupt catalog rather than
+            //  overrun the fixed-size stack buffer (matches the other fidMSO_Name readers).
+            AssertSz( fFalse, "Invalid fidMSO_Name column in catalog." );
+            OSUHAEmitFailureTag( PinstFromPfucb( pfucbCatalog ), HaDbFailureTagCorruption, L"7d2c1f8a-6b34-4e05-9c1a-3f8e2d6b40a9" );
+            Error( ErrERRCheck( JET_errCatalogCorrupted ) );
+        }
+        UtilMemCpy( szObjectNameT, dataField.Pv(), cbObjectName );
+        szObjectNameT[ cbObjectName ] = '\0';
     }
 
 HandleError:

--- a/dev/ese/src/ese/cat.cxx
+++ b/dev/ese/src/ese/cat.cxx
@@ -6493,7 +6493,7 @@ LOCAL ERR ErrCATIBuildFIELDArray(
         if ( fFixedColumn )
         {
             Assert( FidOfColumnid( columnid ) >= ptdb->FidFixedFirst() );
-            Assert( FidOfColumnid( columnid ) <= ptdb->FidTaggedLast() );
+            Assert( FidOfColumnid( columnid ) <= ptdb->FidFixedLast() );
         }
 
         if ( !FNegTest( fInvalidAPIUsage ) && FFIELDFinalize( field.ffield ) && !s_fLimitFinalizeFfieldNyi )

--- a/dev/ese/src/ese/comp.cxx
+++ b/dev/ese/src/ese/comp.cxx
@@ -1240,6 +1240,13 @@ LOCAL ERR ErrCMPCopyTable(
         const ULONG cpgUsed = rgcpgExtent[0] - rgcpgExtent[1];
         Assert( cpgUsed > 0 );
 
+        //  a (corrupt) space tree reporting AvailExt == OwnExt would make cpgUsed 0 and divide by
+        //  zero below; treat it as corruption so the meter progression is suppressed instead.
+        if ( 0 == cpgUsed )
+        {
+            fCorruption = fTrue;
+        }
+
         pstatus->cbRawData = 0;
         pstatus->cbRawDataLV = 0;
         pstatus->cLeafPagesTraversed = 0;

--- a/dev/ese/src/ese/compression.cxx
+++ b/dev/ese/src/ese/compression.cxx
@@ -2096,7 +2096,7 @@ ERR CDataCompressor::ErrCompressLz4_(
     Assert( cbCompressedActual <= cbDataCompressedMax - cbReserved );
 
     PERFOpt( pstats->AddUncompressedBytes( data.Cb() ) );
-    PERFOpt( pstats->AddCompressedBytes( *pcbDataCompressedActual ) );
+    PERFOpt( pstats->AddCompressedBytes( cbCompressedActual + cbReserved ) );
     PERFOpt( pstats->IncCompressionCalls() );
     PERFOpt( pstats->AddCompressionDhrts( HrtHRTCount() - hrtStart ) );
 

--- a/dev/ese/src/ese/cpage.cxx
+++ b/dev/ese/src/ese/cpage.cxx
@@ -6992,7 +6992,9 @@ ERR CPAGE::DumpHeader( CPRINTF * pcprintf, DWORD_PTR dwOffset ) const
                 // calculate the expected tag size
                 USHORT usExpectedTagSize = 1; //for the flag byte
                 BYTE fFlagT = 0x1;
-                for ( INT i = 0; i < noderfMax; ++i, fFlagT <<= 1 )
+                //  g_rgcbExternalHeaderSize has noderfMax entries (0..noderfMax-1); i indexes [i+1],
+                //  so stop at noderfMax-1 to avoid reading one past the end on a corrupt flag byte.
+                for ( INT i = 0; i < noderfMax - 1; ++i, fFlagT <<= 1 )
                 {
                     if ( fFlagT & fNodeFlag )
                     {

--- a/dev/ese/src/ese/dataserializer.cxx
+++ b/dev/ese/src/ese/dataserializer.cxx
@@ -903,8 +903,12 @@ ERR MemoryDataStore::ErrStoreDataToColumn( const char * const szColumn, const vo
     else
     {
         BYTE * pb = new BYTE[cb];
+        if ( pb == NULL )
+        {
+            return ErrERRCheck( JET_errOutOfMemory );
+        }
         memcpy( pb, pv, cb );
-        m_rgpbData[i] = unique_ptr<BYTE>( pb );
+        m_rgpbData[i] = unique_ptr<BYTE[]>( pb );
         m_rgcbData[i] = cb;
         return JET_errSuccess;
     }

--- a/dev/ese/src/ese/dbscan.cxx
+++ b/dev/ese/src/ese/dbscan.cxx
@@ -1733,6 +1733,8 @@ CDBMScanFollower::CDBMScanFollower()
     m_pstate = NULL;
     m_pscanobsFileCheck = NULL;
     m_pscanobsLgriEvents = NULL;
+    m_pscanobsPerfmon = NULL;
+    m_cFollowerSkipsPrePass = 0;
 }
 
 CDBMScanFollower::~CDBMScanFollower()

--- a/dev/ese/src/ese/dbscan.cxx
+++ b/dev/ese/src/ese/dbscan.cxx
@@ -3981,7 +3981,7 @@ ERR DBMScanObserverCleanup::ErrCleanupPrimaryPage_( CSR * const pcsr, DBMObjectC
 
                 // Extract the bookmark
                 // Call ErrBTDelete
-                unique_ptr<BYTE> pbBookmark( new BYTE[kdf.key.Cb()] );
+                unique_ptr<BYTE[]> pbBookmark( new BYTE[kdf.key.Cb()] );
                 Alloc( pbBookmark.get() );
                 kdf.key.CopyIntoBuffer( pbBookmark.get(), kdf.key.Cb() );
                 

--- a/dev/ese/src/ese/dbutil.cxx
+++ b/dev/ese/src/ese/dbutil.cxx
@@ -1137,7 +1137,7 @@ LOCAL_BROKEN ERR ErrDBUTLMungeDatabase(
         {
             return ErrERRCheck( JET_errInvalidParameter );
         }
-        const PGNO pgnoNext = strtoul( rgszCommand[2], NULL, 0 );
+        const PGNO pgnoNext = strtoul( rgszCommand[2], &pchEnd, 0 );
         if( 0 != *pchEnd )
         {
             return ErrERRCheck( JET_errInvalidParameter );
@@ -1155,7 +1155,7 @@ LOCAL_BROKEN ERR ErrDBUTLMungeDatabase(
         {
             return ErrERRCheck( JET_errInvalidParameter );
         }
-        const PGNO pgnoPrev = strtoul( rgszCommand[2], NULL, 0 );
+        const PGNO pgnoPrev = strtoul( rgszCommand[2], &pchEnd, 0 );
         if( 0 != *pchEnd )
         {
             return ErrERRCheck( JET_errInvalidParameter );
@@ -1173,7 +1173,7 @@ LOCAL_BROKEN ERR ErrDBUTLMungeDatabase(
         {
             return ErrERRCheck( JET_errInvalidParameter );
         }
-        const ULONG fFlags = strtoul( rgszCommand[2], NULL, 0 );
+        const ULONG fFlags = strtoul( rgszCommand[2], &pchEnd, 0 );
         if( 0 != *pchEnd )
         {
             return ErrERRCheck( JET_errInvalidParameter );

--- a/dev/ese/src/ese/dir.cxx
+++ b/dev/ese/src/ese/dir.cxx
@@ -2588,7 +2588,14 @@ LOCAL ERR ErrDIRIIRefresh( FUCB * const pfucb )
         bm.key.prefix.Nullify();
         bm.key.suffix = pfucbIdx->kdfCurr.data;
 
-        Call( ErrDIRGotoBookmark( pfucb, bm ) );
+        err = ErrDIRGotoBookmark( pfucb, bm );
+        if ( err < 0 )
+        {
+            //  pfucbIdx is a distinct secondary-index cursor left read-latched by ErrBTDown above;
+            //  release its latch before erroring out so we don't leak the page latch.
+            CallS( ErrBTRelease( pfucbIdx ) );
+            goto HandleError;
+        }
     }
 
     Call( ErrBTRelease( pfucbIdx ) );

--- a/dev/ese/src/ese/fcreate.cxx
+++ b/dev/ese/src/ese/fcreate.cxx
@@ -7675,7 +7675,7 @@ LOCAL ERR VTAPI ErrFILEIBatchCreateIndex(
         }
 
         // Force a write to the output structure (but don't actually modify the value).
-        OnDebug( AtomicCompareExchange( &pidxcreate->err, pidxcreate->err, pidxcreate->err ) );
+        OnDebug( AtomicCompareExchange( &pidxcreateT->err, pidxcreateT->err, pidxcreateT->err ) );
 
         if ( fLazyCommit && !( pidxcreateT->grbit & JET_bitIndexLazyFlush ) )
         {
@@ -7688,7 +7688,7 @@ LOCAL ERR VTAPI ErrFILEIBatchCreateIndex(
         pfcb->GetAPISpaceHints( &jsphIndex );
         if ( pidxcreateT->pSpacehints )
         {
-            jsphIndex = *(pidxcreate->pSpacehints);
+            jsphIndex = *(pidxcreateT->pSpacehints);
         }
         if ( ( (ULONG)g_cbPage * cpgInitialTreeDefault ) == jsphIndex.cbInitial )
         {
@@ -8349,7 +8349,7 @@ ERR VTAPI ErrIsamCreateIndex(
         {
             Assert( sizeof(JET_INDEXCREATE3_A) == pindexcreateT->cbStruct );
 
-            if ( pindexcreate->grbit & JET_bitIndexDeferredPopulateProcess )
+            if ( pindexcreateT->grbit & JET_bitIndexDeferredPopulateProcess )
             {
                 // Trying to continue processing a deferred-populate index.
 
@@ -8368,12 +8368,12 @@ ERR VTAPI ErrIsamCreateIndex(
                     Error( ErrERRCheck( JET_errIllegalOperation ) );
                 }
 
-                Call( ErrFILEIProcessDeferredPopulateIndex( ppib, pfucbTable, pindexcreate ) );
+                Call( ErrFILEIProcessDeferredPopulateIndex( ppib, pfucbTable, pindexcreateT ) );
             }
             else
             {
                 // Trying to create a single index, deferred-populate or not.
-                if ( pindexcreate->grbit & JET_bitIndexDeferredPopulateCreate )
+                if ( pindexcreateT->grbit & JET_bitIndexDeferredPopulateCreate )
                 {
                     // Trying to create a single deferred-populate index.
                     if ( !fAllowDeferred )
@@ -8391,7 +8391,7 @@ ERR VTAPI ErrIsamCreateIndex(
                     Assert ( pfmp->PkvpsMSysDeferredPopulateKeys() );
                 }
 
-                Call( ErrFILEICreateIndex( ppib, pfucbTable, pindexcreate ) );
+                Call( ErrFILEICreateIndex( ppib, pfucbTable, pindexcreateT ) );
             }
             fLazyCommit = fLazyCommit && ( pindexcreateT->grbit & JET_bitIndexLazyFlush );
         }

--- a/dev/ese/src/ese/fileopen.cxx
+++ b/dev/ese/src/ese/fileopen.cxx
@@ -2700,6 +2700,13 @@ ERR ErrIDBSetIdxSeg(
         return JET_errSuccess;
     }
 
+    //  cidxseg is derived from a persisted catalog column length; a corrupt value larger than
+    //  the fixed rgidxseg[] stack array would overflow it in the conversion loop below.
+    if ( cidxseg > _countof( rgidxseg ) )
+    {
+        return ErrERRCheck( JET_errCatalogCorrupted );
+    }
+
     //  If it is on little endian machine, we still copy it into
     //  the stack array which is aligned.
     //  If it is on big endian machine, we always need to convert first.
@@ -2800,6 +2807,13 @@ ERR ErrIDBSetIdxSegFromOldFormat(
     TCIB        tcibTemplateTable           = { FID( ptdb->FidFixedFirst()-1 ),
                                                 FID( ptdb->FidVarFirst()-1 ),
                                                 FID( ptdb->FidTaggedFirst()-1 ) };
+
+    //  cidxseg is derived from a persisted catalog column length; a corrupt value larger than
+    //  the fixed rgidxseg[] stack array would overflow it in SetIdxSegFromOldFormat below.
+    if ( cidxseg > _countof( rgidxseg ) )
+    {
+        return ErrERRCheck( JET_errCatalogCorrupted );
+    }
 #ifdef DEBUG
     if ( ptdb->FDerivedTable() )
     {

--- a/dev/ese/src/ese/fldenum.cxx
+++ b/dev/ese/src/ese/fldenum.cxx
@@ -1096,25 +1096,17 @@ LOCAL ERR ErrRECIParseColumnReference(
     BYTE*   rgbDatabaseSignature;
     BYTE*   rgbBookmark;
 
+    //  determine the minimum size for the versioned structure and validate that the
+    //  buffer is large enough BEFORE reading any versioned fields.  this avoids an
+    //  out-of-bounds read of a truncated, caller-supplied column reference.
+
     if ( pcrfc->m_crfi == crfiV1 )
     {
         cbReferenceMinExpected = sizeof( CColumnReferenceFormatV1 );
-        cbBookmark = pcrfv1->m_cbBookmark;
-        cbColumnName = pcrfv1->m_cbColumnName;
-        itagSequence = pcrfv1->m_itagSequence;
-        lid = (_LID32)pcrfv1->m_lid;
-        rgbDatabaseSignature = const_cast<BYTE*>( pcrfv1->m_rgbDatabaseSignature );
-        rgbBookmark = const_cast<BYTE*>( pcrfv1->m_rgbBookmark );
     }
     else if ( pcrfc->m_crfi == crfiV2 )
     {
         cbReferenceMinExpected = sizeof( CColumnReferenceFormatV2 );
-        cbBookmark = pcrfv2->m_cbBookmark;
-        cbColumnName = pcrfv2->m_cbColumnName;
-        itagSequence = pcrfv2->m_itagSequence;
-        lid = pcrfv2->m_lid;
-        rgbDatabaseSignature = const_cast<BYTE*>( pcrfv2->m_rgbDatabaseSignature );
-        rgbBookmark = const_cast<BYTE*>( pcrfv2->m_rgbBookmark );
     }
     else
     {
@@ -1124,6 +1116,26 @@ LOCAL ERR ErrRECIParseColumnReference(
     if ( cbReference < cbReferenceMinExpected )
     {
         Error( ErrERRCheck( JET_errInvalidColumnReference ) );
+    }
+
+    if ( pcrfc->m_crfi == crfiV1 )
+    {
+        cbBookmark = pcrfv1->m_cbBookmark;
+        cbColumnName = pcrfv1->m_cbColumnName;
+        itagSequence = pcrfv1->m_itagSequence;
+        lid = (_LID32)pcrfv1->m_lid;
+        rgbDatabaseSignature = const_cast<BYTE*>( pcrfv1->m_rgbDatabaseSignature );
+        rgbBookmark = const_cast<BYTE*>( pcrfv1->m_rgbBookmark );
+    }
+    else
+    {
+        Assert( pcrfc->m_crfi == crfiV2 );
+        cbBookmark = pcrfv2->m_cbBookmark;
+        cbColumnName = pcrfv2->m_cbColumnName;
+        itagSequence = pcrfv2->m_itagSequence;
+        lid = pcrfv2->m_lid;
+        rgbDatabaseSignature = const_cast<BYTE*>( pcrfv2->m_rgbDatabaseSignature );
+        rgbBookmark = const_cast<BYTE*>( pcrfv2->m_rgbBookmark );
     }
     if ( cbBookmark <= 0 || cbBookmark > ( pfucb->u.pfcb->Pidb() ? pfucb->u.pfcb->Pidb()->CbKeyMost() : sizeof( DBK ) ) )
     {
@@ -3895,6 +3907,19 @@ LOCAL ERR ErrRECIStreamRecordsOnPrimaryIndexIAppendColumnValues(
         //  emit this column value
 
         Call( ErrRECIStreamRecordsIAppendColumnValue( pcontext, columnid, errData, cbData, pvData ) );
+
+        //  free the per-column-value working buffers before processing the next value so that
+        //  multi-valued columns do not leak all but the last allocation.  the error path frees
+        //  the current iteration's buffers in HandleError.
+
+        delete[] pbDataReference;
+        pbDataReference = NULL;
+        delete[] pbDataDecrypted;
+        pbDataDecrypted = NULL;
+        delete[] pbDataDecompressed;
+        pbDataDecompressed = NULL;
+        delete[] pbDataAdjusted;
+        pbDataAdjusted = NULL;
     }
 
     //  if there were no column values then emit an explicit null column value

--- a/dev/ese/src/ese/fldext.cxx
+++ b/dev/ese/src/ese/fldext.cxx
@@ -625,7 +625,9 @@ INLINE ULONG UlRECICountTaggedColumnInstances(
     if ( dataRec.Cb() < REC::cbRecordMin || dataRec.Cb() > REC::CbRecordMostCHECK( g_rgfmp[ pfcb->Ifmp() ].CbPage() ) )
     {
         FireWall( "RECICountTaggedColInstsRecTooBig15.1" );
-        return ErrERRCheck( JET_errDatabaseCorrupted );
+        //  this returns a ULONG count, so an ERR cannot be propagated (a negative ERR would be
+        //  reinterpreted as a huge instance count); report zero instances on the corruption path.
+        return 0;
     }
 
     if ( FCOLUMNIDTemplateColumn( columnid ) )
@@ -1373,7 +1375,9 @@ ComputeItag:
                 {
                     for ( ichOffset = pidb->IchTuplesStart() + pidb->CchTuplesIncrement(), ulTuple = 1; ulTuple < pidb->IchTuplesToIndexMax(); ichOffset += pidb->CchTuplesIncrement(), ulTuple++ )
                     {
-                        CallR( ErrRECRetrieveKeyFromRecord(
+                        //  use Call (not CallR) so an error routes through HandleError, which frees
+                        //  pbKeyRes (RESKEY pool); a bare return here would leak the key buffer.
+                        Call( ErrRECRetrieveKeyFromRecord(
                                     pfucb,
                                     pidb,
                                     &keyT,
@@ -1774,7 +1778,10 @@ ERR VTAPI ErrIsamRetrieveColumn(
             Call( ErrERRCheck( JET_errInvalidTableId ) );
         }
         
-        *pcbActual = sizeof(PGNO);
+        if ( pcbActual )
+        {
+            *pcbActual = sizeof(PGNO);
+        }
         if ( !pv || sizeof(PGNO) > cbMax )
         {
             Call( ErrERRCheck( JET_errBufferTooSmall ) );
@@ -1800,7 +1807,10 @@ ERR VTAPI ErrIsamRetrieveColumn(
             Call( ErrERRCheck( JET_errInvalidTableId ) );
         }
         
-        *pcbActual = sizeof(ULONG);
+        if ( pcbActual )
+        {
+            *pcbActual = sizeof(ULONG);
+        }
         if ( !pv || sizeof(ULONG) > cbMax )
         {
             Call( ErrERRCheck( JET_errBufferTooSmall ) );
@@ -2461,7 +2471,7 @@ LOCAL ERR ErrRECRetrieveColumns(
             
             //  no ibLongValue since that logical concept cannot be compbined with JET_bitRetrievePhysicalSize, and no cbData since no data returned
             //
-            if ( pretcol->cbData || pretcol->ibLongValue )
+            if ( pretcolT->cbData || pretcolT->ibLongValue )
             {
                 Call( ErrERRCheck( JET_errInvalidParameter ) );
             }
@@ -2783,7 +2793,7 @@ LOCAL ERR ErrRECRetrieveColumns(
         else
         {
             Assert( wrnRECLongField != err );       //  obsolete error code
-            Assert( !(grbit & JET_bitRetrievePhysicalSize ) || pretcol->ibLongValue == 0 );
+            Assert( !(grbit & JET_bitRetrievePhysicalSize ) || pretcolT->ibLongValue == 0 );
 
             switch ( err )
             {
@@ -3231,11 +3241,13 @@ LOCAL ERR ErrRECIBuildTaggedColumnList(
             //  column is visible to us
             if( !fCountOnly )
             {
+                //  when the current column comes from the default-values iterator it exists only
+                //  as a default (the record iterator takes precedence on ties), so flag it as such.
                 RECIAddTaggedColumnListEntry(
                     rgtagcolinfo + centriesCurr,
                     pIteratorCur,
                     ptdb,
-                    fFalse );
+                    ( pIteratorCur == pdefaultValuesIterator ) );
             }
             ++centriesCurr;
             if( centriesMax == centriesCurr )

--- a/dev/ese/src/ese/fldmod.cxx
+++ b/dev/ese/src/ese/fldmod.cxx
@@ -2588,12 +2588,14 @@ ERR ErrRECISetFixedColumnInLoadedDataBuffer(
 }
 
 
-INLINE ULONG CbBurstVarDefaults( TDB *ptdb, FUCB *pfucb, FID fidVarLastInRec, FID fidSet, FID *pfidLastDefault )
+INLINE ERR ErrCbBurstVarDefaults( TDB *ptdb, FUCB *pfucb, FID fidVarLastInRec, FID fidSet, FID *pfidLastDefault, _Out_ ULONG * const pcbBurstDefaults )
 {
     ULONG               cbBurstDefaults     = 0;
     const REC * const   precDefault         = ( NULL != ptdb->PdataDefaultRecord() ?
                                                         (REC *)ptdb->PdataDefaultRecord()->Pv() :
                                                         NULL );
+
+    *pcbBurstDefaults = 0;
 
     // Compute space needed to burst default values.
     // Default values may have to be burst if there are default value columns
@@ -2662,7 +2664,8 @@ INLINE ULONG CbBurstVarDefaults( TDB *ptdb, FUCB *pfucb, FID fidVarLastInRec, FI
     Assert( cbBurstDefaults == 0  ||
         ( *pfidLastDefault > fidVarLastInRec && *pfidLastDefault < fidSet ) );
 
-    return cbBurstDefaults;
+    *pcbBurstDefaults = cbBurstDefaults;
+    return JET_errSuccess;
 }
 
 
@@ -2768,12 +2771,19 @@ ERR ErrRECISetVarColumn(
         //  compute space needed for new var column offsets
         //
         const INT   cbNeed = ( fid - fidVarLastInRec ) * sizeof(REC::VAROFFSET);
-        const INT   cbBurstDefaults = CbBurstVarDefaults(
+        ULONG       cbBurstDefaultsT = 0;
+        const ERR   errBurstDefaults = ErrCbBurstVarDefaults(
                                             ptdb,
                                             pfucb,
                                             fidVarLastInRec,
                                             fid,
-                                            &fidLastDefault );
+                                            &fidLastDefault,
+                                            &cbBurstDefaultsT );
+        if ( errBurstDefaults < JET_errSuccess )
+        {
+            return errBurstDefaults;
+        }
+        const INT   cbBurstDefaults = (INT)cbBurstDefaultsT;
 
         if ( cbRec + cbNeed + cbBurstDefaults + cbCopy > REC::CbRecordMost( pfucb ) )
             return ErrERRCheck( JET_errRecordTooBig );

--- a/dev/ese/src/ese/flushmap.cxx
+++ b/dev/ese/src/ese/flushmap.cxx
@@ -439,6 +439,10 @@ ERR CFlushMap::ErrAttachFlushMap_()
                 Assert( cfmpgActual >= 0 ); // the flush map may have zero data pages if we crashed before completing the first full
                                             // write of the map to persistent storage.
                 cfmpgActual = max( cfmpgActual, 1 );
+                //  the page count derives from the (untrusted) persisted flush-map file size; clamp it
+                //  to the maximum a valid flush map can require so a crafted over-large file cannot
+                //  overflow the 32-bit descriptor-capacity arithmetic in ErrAllocateDescriptorsCapacity_.
+                cfmpgActual = min( cfmpgActual, CfmpgGetRequiredFmDataPageCount_( pgnoSysMax ) );
 
                 if ( !m_fDumpMode )
                 {

--- a/dev/ese/src/ese/info.cxx
+++ b/dev/ese/src/ese/info.cxx
@@ -2151,7 +2151,7 @@ LOCAL ERR ErrInfoGetTableColumnInfoList(
 
     Assert( fidFixedFirst.FFixed() || ( ( pfcbNil != ptdb->PfcbTemplateTable() ) && fidFixedFirst.FFixedNoneFull() ) );
     Assert( fidVarFirst.FVar() || ( ( pfcbNil != ptdb->PfcbTemplateTable() ) && fidVarFirst.FVarNoneFull() ) );
-    Assert( fidTaggedFirst.FTagged() || ( (pfcbNil != ptdb->PfcbTemplateTable() ) && fidVarFirst.FTaggedNoneFull() ) );
+    Assert( fidTaggedFirst.FTagged() || ( (pfcbNil != ptdb->PfcbTemplateTable() ) && fidTaggedFirst.FTaggedNoneFull() ) );
 
     Assert( fidFixedLast.FFixedNone() || fidFixedLast.FFixed() );
     Assert( fidVarLast.FVarNone() || fidVarLast.FVar() );

--- a/dev/ese/src/ese/jetapi.cxx
+++ b/dev/ese/src/ese/jetapi.cxx
@@ -8387,8 +8387,10 @@ void CAutoINDEXCREATE3To3_T< JET_INDEXCREATE3_T_FROM, JET_INDEXCREATE3_T_TO >::R
         if ( 0 == ( m_rgindexcreateEngine[iIdx].grbit & JET_bitIndexImmutableStructure ) )
         {
             pidxcreateFromAPI->err = m_rgindexcreateEngine[iIdx].err;
-            pidxcreateFromAPI = (JET_INDEXCREATE3_T_FROM *)( ((BYTE*)pidxcreateFromAPI) + pidxcreateFromAPI->cbStruct );
         }
+        //  Advance unconditionally so the client pointer stays in sync with iIdx even when
+        //  some structures are immutable -- only the write-back is skipped, not the walk.
+        pidxcreateFromAPI = (JET_INDEXCREATE3_T_FROM *)( ((BYTE*)pidxcreateFromAPI) + pidxcreateFromAPI->cbStruct );
     }
 }
 template< class JET_INDEXCREATE3_T_FROM, class JET_INDEXCREATE3_T_TO >
@@ -14966,6 +14968,10 @@ void CAutoIDXCREATE3::Result( )
     {
         m_pindexcreate2W->err = m_pindexcreate->err;
     }
+    else if ( m_pindexcreate && m_pindexcreate3W )
+    {
+        m_pindexcreate3W->err = m_pindexcreate->err;
+    }
 }
 
 CAutoIDXCREATE3::~CAutoIDXCREATE3()
@@ -16417,6 +16423,9 @@ LOCAL JET_ERR JetCreateIndexEx2W(
     //
     for( iIndexCreate = 0 ; iIndexCreate < cIndexCreate; iIndexCreate++ )
     {
+        //  the engine wrote each per-index result into the separate engine array, so copy it
+        //  back into the converter before Result() propagates it to the client structure.
+        ((JET_INDEXCREATE2_A*)(rgindexcreateauto[iIndexCreate]))->err = rgindexcreateEngine[iIndexCreate].err;
         rgindexcreateauto[iIndexCreate].Result( );
     }
 
@@ -16486,6 +16495,9 @@ LOCAL JET_ERR JetCreateIndexEx1W(
     //
     for( iIndexCreate = 0 ; iIndexCreate < cIndexCreate; iIndexCreate++ )
     {
+        //  the engine wrote each per-index result into the separate engine array, so copy it
+        //  back into the converter before Result() propagates it to the client structure.
+        ((JET_INDEXCREATE2_A*)(rgindexcreateauto[iIndexCreate]))->err = rgindexcreateEngine[iIndexCreate].err;
         rgindexcreateauto[iIndexCreate].Result( );
     }
 
@@ -16534,6 +16546,9 @@ LOCAL JET_ERR JetCreateIndexEx3W(
     //
     for( iIndexCreate = 0 ; iIndexCreate < cIndexCreate; iIndexCreate++ )
     {
+        //  the engine wrote each per-index result into the separate engine array, so copy it
+        //  back into the converter before Result() propagates it to the client structure.
+        ((JET_INDEXCREATE3_A*)(rgindexcreateauto[iIndexCreate]))->err = rgindexcreateEngine[iIndexCreate].err;
         rgindexcreateauto[iIndexCreate].Result( );
     }
 

--- a/dev/ese/src/ese/kvpstore.cxx
+++ b/dev/ese/src/ese/kvpstore.cxx
@@ -248,7 +248,7 @@ ERR CKVPStore::ErrKVPIInitICreateTable( PIB * ppib, const IFMP ifmp, const CHAR 
     Assert( m_cidKey == rgcolumncreateKVPTable[0].columnid );
     Assert( m_cidType == rgcolumncreateKVPTable[1].columnid );
     Assert( m_rgDataTypeInfo[kvpvtSchemaValueType].m_type == kvpvtSchemaValueType );
-    Assert( m_rgDataTypeInfo[kvpvtSchemaValueType].m_cid = rgcolumncreateKVPTable[2].columnid );
+    Assert( m_rgDataTypeInfo[kvpvtSchemaValueType].m_cid == rgcolumncreateKVPTable[2].columnid );
 
     //  first time we've used this table, initialize the schema elements for Internal version numbers.
     //

--- a/dev/ese/src/ese/lv.cxx
+++ b/dev/ese/src/ese/lv.cxx
@@ -5170,7 +5170,7 @@ ERR ErrRECGetLVSize(
 
         Assert( FIsLVChunkKey( pfucbLV->kdfCurr.key ) );
         *pcbLVDataPhysical  += pfucbLV->kdfCurr.data.Cb();
-        *pcbLVOverhead      += ( CPAGE::cbInsertionOverhead + cbKeyCount + pfucb->kdfCurr.key.Cb() );
+        *pcbLVOverhead      += ( CPAGE::cbInsertionOverhead + cbKeyCount + pfucbLV->kdfCurr.key.Cb() );
 
         ulOffset += pfucb->u.pfcb->Ptdb()->CbLVChunkMost();
     }

--- a/dev/ese/src/ese/lv.cxx
+++ b/dev/ese/src/ese/lv.cxx
@@ -1598,7 +1598,7 @@ LOCAL ERR ErrLVIDecompressAndCompare(
     if ( ( cbDecompressed - ibOffset ) < cbData )
     {
         LVReportAndTrapCorruptedLV( pfucbLV, lid, L"989222f8-ff0d-46a6-a58a-86f5c9cb472a" );
-        return ErrERRCheck( JET_errLVCorrupted );
+        Error( ErrERRCheck( JET_errLVCorrupted ) );
     }
     
     if ( 0 != memcmp( pbData, pbDecompressed + ibOffset, cbData ) )
@@ -1656,6 +1656,7 @@ LOCAL ERR ErrLVIDecompress(
         if( (ULONG)( ibOffset + cbData ) > (ULONG)cbDecompressed )
         {
             LVReportAndTrapCorruptedLV( pfucbLV, lid, L"6c499d75-2c5f-432a-bcf9-6de555ac0d7f" );
+            delete[] pbDecompressed;
             return ErrERRCheck( JET_errLVCorrupted );
         }
         UtilMemCpy( pbData, pbDecompressed+ibOffset, cbData );

--- a/dev/ese/src/ese/node.cxx
+++ b/dev/ese/src/ese/node.cxx
@@ -2540,6 +2540,13 @@ ERR LOCAL ErrNDISetExternalHeader( _In_ FUCB* const pfucb, _In_ const IFMP ifmp,
     const SIZE_T cbPostcedingStoredFields = (BYTE*)line.pv + line.cb - pbCursorSrc;
     if ( cbPostcedingStoredFields > 0 )
     {
+        //  cbPostcedingStoredFields derives from the persisted external-header size (line.cb) and
+        //  can be corrupt-large, or underflow to ~SIZE_MAX if a bad flag byte walked pbCursorSrc
+        //  past the tag; bound it to the remaining stack buffer like the two copies above.
+        if ( cbPostcedingStoredFields > (SIZE_T)( _countof(pbBuffer) - (ULONG)( pbCursorDst - (BYTE*)pbBuffer ) ) )
+        {
+            Error( ErrERRCheck( JET_errInvalidBufferSize ) );
+        }
         UtilMemCpy( pbCursorDst, pbCursorSrc, cbPostcedingStoredFields );
         pbCursorDst += cbPostcedingStoredFields;
         AssertRTL( pbCursorDst - (BYTE*)pbBuffer <= _countof(pbBuffer) );

--- a/dev/ese/src/ese/node_test.cxx
+++ b/dev/ese/src/ese/node_test.cxx
@@ -679,7 +679,7 @@ JETUNITTESTEX ( Node, TestCorruptPrefixCbFullFuzzResilientCodePaths, JetSimpleUn
     // if these are offended, someone has made us stricter (that's good), but consider re-running this test infinitely 
     // to find the new max values for above checks.
     CHECK( cGoodSmall > 100 );  
-    CHECK( cGoodSmall > 125 );
+    CHECK( cGoodLarge > 125 );
 
     // last modification is + 0x10000, which doesn't modify a USHORT, so should have min two successes.
     CHECK( cGoodSmall > 2 );
@@ -787,7 +787,7 @@ JETUNITTESTEX ( Node, TestCorruptSuffixCbFullFuzzResilientCodePaths, JetSimpleUn
     // if these are offended, someone has made us stricter (that's good), but consider re-running this test infinitely 
     // to find the new max values for above checks.
     CHECK( cGoodSmall > 550 );
-    CHECK( cGoodSmall > 450 );
+    CHECK( cGoodLarge > 450 );
 
     // last modification is + 0x10000, which doesn't modify a USHORT, so should have min two successes.
     CHECK( cGoodSmall > 2 );
@@ -1048,7 +1048,7 @@ JETUNITTESTEX ( Node, TestCorruptTagIbFullFuzzResilientCodePaths, JetSimpleUnitT
     // If these are offended, someone has made us stricter (that's good), but consider re-running this test infinitely 
     // to find the new max & min values for this range of checks above and below this comment.
     CHECK( cGoodSmall > 6100 );  
-    CHECK( cGoodSmall > 1500 );
+    CHECK( cGoodLarge > 1500 );
 
     // last modification is + 0x10000, which doesn't modify a USHORT, so should have a min two successes - no matter what.
     CHECK( cGoodSmall > 2 );

--- a/dev/ese/src/ese/old.cxx
+++ b/dev/ese/src/ese/old.cxx
@@ -1051,9 +1051,11 @@ ERR RECCHECKFINALIZE<TDelta>::operator()( const KEYDATAFLAGS& kdf, const PGNO pg
         return JET_errSuccess;
     }
 
-    //  Currently all finalizable columns are ULONGs
-    const ULONG ulColumn        = *(UnalignedLittleEndian< ULONG > *)((BYTE *)prec + m_ibRecordOffset );
-    if ( 0 == ulColumn )
+    //  Finalizable columns are 32-bit and 64-bit signed types (see FINALIZETASK<TDelta>).
+    //  Read the full column width: a 64-bit escrow value whose low 32 bits happen to be zero
+    //  (but which is non-zero overall) must not be mistaken for zero.
+    const TDelta tColumn        = *(UnalignedLittleEndian< TDelta > *)((BYTE *)prec + m_ibRecordOffset );
+    if ( 0 == tColumn )
     {
         BOOKMARK bm;
         bm.key = kdf.key;

--- a/dev/ese/src/ese/rbscleaner_test.cxx
+++ b/dev/ese/src/ese/rbscleaner_test.cxx
@@ -344,7 +344,7 @@ ERR RBSCleanerTestIOOperator::ErrRemoveFolder( PCWSTR wszDirPath, PCWSTR wszRBSR
 ERR RBSCleanerTestIOOperator::ErrRBSAbsRootDirPathToUse( __out_bcount( cbDirPath ) WCHAR* wszRBSAbsRootDirPath, LONG cbDirPath, BOOL fBackupDir )
 {
    // doesn't matter what we return for test here as it doesn't affect the values we return in the current usage.
-   ErrOSStrCbCopyW( wszRBSAbsRootDirPath, sizeof( wszRBSAbsRootDirPath ), wszRBSBackupDir );
+   ErrOSStrCbCopyW( wszRBSAbsRootDirPath, cbDirPath, wszRBSBackupDir );
    return JET_errSuccess;
 }
 

--- a/dev/ese/src/ese/rbsdump.cxx
+++ b/dev/ese/src/ese/rbsdump.cxx
@@ -74,7 +74,9 @@ VOID LOCAL DUMPRBSHeaderStandard( INST *pinst, _In_ const DB_HEADER_READER* cons
 
     DUMPPrintF( "Snapshot Attach Infos:\n" );
 
-    for( const BYTE * pbT = prbsfilehdr->rgbAttach; 0 != *pbT; pbT += sizeof( RBSATTACHINFO ) )
+    for( const BYTE * pbT = prbsfilehdr->rgbAttach;
+         pbT + sizeof( RBSATTACHINFO ) <= prbsfilehdr->rgbAttach + cbRBSAttach && 0 != *pbT;
+         pbT += sizeof( RBSATTACHINFO ) )
     {
         RBSATTACHINFO* prbsattachinfo = (RBSATTACHINFO*) pbT;
 
@@ -230,7 +232,9 @@ VOID RBSRecToSz( const RBSRecord *prbsrec, __out_bcount(cbRBSRec) PSTR szRBSRec,
 
             RBSDbPageRecord* prbsdbpgrec = ( RBSDbPageRecord* ) prbsrec;
             dataImage.SetPv( prbsdbpgrec->m_rgbData );
-            dataImage.SetCb( prbsrec->m_usRecLength - sizeof(RBSDbPageRecord) );
+            dataImage.SetCb( prbsrec->m_usRecLength >= sizeof( RBSDbPageRecord )
+                                ? prbsrec->m_usRecLength - sizeof( RBSDbPageRecord )
+                                : 0 );
 
             if ( prbsdbpgrec->m_fFlags )
             {
@@ -554,6 +558,10 @@ ERR ErrDUMPRBSPage( INST *pinst, _In_ PCWSTR wszRBS, PGNO pgnoFirst, PGNO pgnoLa
     }
 
     prbs = new CRevertSnapshot( pinst );
+    if ( prbs == NULL )
+    {
+        Error( ErrERRCheck( JET_errOutOfMemory ) );
+    }
     Call ( prbs->ErrSetRBSFileApi( pfapirbs ) );
     Call ( prbs->ErrSetReadBuffer( pgnoFirst ) );
     prbs->SetIsDumping();

--- a/dev/ese/src/ese/rec.cxx
+++ b/dev/ese/src/ese/rec.cxx
@@ -2605,7 +2605,7 @@ HandleError:
     Expected( err >= JET_errSuccess || *ppKey == NULL );
     if ( err < JET_errSuccess )
     {
-        delete *ppKey;
+        delete[] *ppKey;
         *ppKey = NULL;
         *pcKey = 0;
     }
@@ -3050,7 +3050,7 @@ ERR ErrIsamIPrereadIndexRanges(
     {
         if ( grbit & JET_bitPrereadNormalizedKey )
         {
-            if ( rgIndexRanges[iindexrangeT].cStartColumns != 1 &&
+            if ( rgIndexRanges[iindexrangeT].cStartColumns != 1 ||
                  rgIndexRanges[iindexrangeT].cEndColumns > 1 )
             {
                 Error( ErrERRCheck( JET_errInvalidParameter ) );

--- a/dev/ese/src/ese/rec.cxx
+++ b/dev/ese/src/ese/rec.cxx
@@ -626,6 +626,16 @@ ERR ErrRECSetCursorFilter(
     DWORD   cbNeeded    = sizeof(NORMALIZED_FILTER_COLUMN) * cFilters;
     for ( DWORD i = 0; i < cFilters; i++ )
     {
+        //  no supported filter column can hold more than JET_cbColumnMost bytes, so a larger
+        //  filter value is invalid.  Reject it here so that the buffer-size accumulation below
+        //  (a 32-bit DWORD) cannot be made to overflow, which would under-allocate the buffer
+        //  and cause a heap overflow when the filter value is copied in later.
+        //
+        if ( rgFilters[i].cb > JET_cbColumnMost )
+        {
+            Error( ErrERRCheck( JET_errInvalidParameter ) );
+        }
+
         //  add an extra byte in case the filter value needs to be normalised
         //  (because a prefix/header byte will be pre-pended to the normalised
         //  value)

--- a/dev/ese/src/ese/repair.cxx
+++ b/dev/ese/src/ese/repair.cxx
@@ -7506,8 +7506,16 @@ LOCAL ERR ErrREPAIRICheckInternalLine(
             ++(pbtstats->cnodeCompressed);
         }
         pbtstats->cbDataInternal += kdfCurr.data.Cb();
-        ++(pbtstats->rgckeyInternal[kdfCurr.key.Cb()]);
-        ++(pbtstats->rgckeySuffixInternal[kdfCurr.key.suffix.Cb()]);
+        //  key/suffix lengths come from a (possibly corrupt) persisted node; the histogram
+        //  arrays only have cbKeyAlloc buckets, so bound the index to avoid an OOB write.
+        if ( (ULONG)kdfCurr.key.Cb() < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeyInternal[kdfCurr.key.Cb()]);
+        }
+        if ( (ULONG)kdfCurr.key.suffix.Cb() < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeySuffixInternal[kdfCurr.key.suffix.Cb()]);
+        }
 
 HandleTryError:
         ;
@@ -7573,7 +7581,12 @@ LOCAL ERR ErrREPAIRCheckInternal(
     else
     {
         NDGetPtrExternalHeader( csr.Cpage(), &line, noderfWhole );
-        ++(pbtstats->rgckeyPrefixInternal[line.cb]);
+        //  line.cb (prefix size) is bounded only by the page; the histogram has cbKeyAlloc
+        //  buckets, so bound the index to avoid an OOB write on a corrupt page.
+        if ( (ULONG)line.cb < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeyPrefixInternal[line.cb]);
+        }
     }
     if ( pbtstats->cpageDepth <= 0 )
     {
@@ -7715,8 +7728,16 @@ LOCAL ERR ErrREPAIRICheckLeafLine(
         }
 
         pbtstats->cbDataLeaf += kdfCurr.data.Cb();
-        ++(pbtstats->rgckeyLeaf[kdfCurr.key.Cb()]);
-        ++(pbtstats->rgckeySuffixLeaf[kdfCurr.key.suffix.Cb()]);
+        //  key/suffix lengths come from a (possibly corrupt) persisted node; the histogram
+        //  arrays only have cbKeyAlloc buckets, so bound the index to avoid an OOB write.
+        if ( (ULONG)kdfCurr.key.Cb() < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeyLeaf[kdfCurr.key.Cb()]);
+        }
+        if ( (ULONG)kdfCurr.key.suffix.Cb() < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeySuffixLeaf[kdfCurr.key.suffix.Cb()]);
+        }
 
 HandleTryError:
         ;
@@ -7787,7 +7808,12 @@ LOCAL ERR ErrREPAIRCheckLeaf(
     else
     {
         NDGetPtrExternalHeader( csr.Cpage(), &line, noderfWhole );
-        ++(pbtstats->rgckeyPrefixLeaf[line.cb]);
+        //  line.cb (prefix size) is bounded only by the page; the histogram has cbKeyAlloc
+        //  buckets, so bound the index to avoid an OOB write on a corrupt page.
+        if ( (ULONG)line.cb < cbKeyAlloc )
+        {
+            ++(pbtstats->rgckeyPrefixLeaf[line.cb]);
+        }
     }
 
     if ( pbtstats->cpageDepth <= 0 )
@@ -8943,12 +8969,15 @@ LOCAL ERR ErrREPAIRInsertCatalogRecordIntoTempTable(
     BYTE rgbKey[JET_cbKeyMost_OLD];
     kdf.key.CopyIntoBuffer( rgbKey, sizeof( rgbKey ) );
 
+    //  CopyIntoBuffer truncates to sizeof(rgbKey); a corrupt catalog node can have a key longer
+    //  than that, so cap the reported length to what was actually copied to avoid reading past
+    //  the stack buffer.
     Call( ErrDispSetColumn(
                 sesid,
                 tableid,
                 columnidKey,
                 rgbKey,
-                kdf.key.Cb(),
+                min( (ULONG)kdf.key.Cb(), (ULONG)sizeof( rgbKey ) ),
                 0,
                 NULL ) );
 

--- a/dev/ese/src/ese/revertsnapshot.cxx
+++ b/dev/ese/src/ese/revertsnapshot.cxx
@@ -6484,7 +6484,7 @@ ERR CRBSRevertContext::ErrRemoveRBSAfterRevert()
     ERR     err         = JET_errSuccess;
 
     // Backup all the RBS generations we have applied in case we need them for investigation later.
-    for ( LONG rbsGenToBackup = m_lRBSMaxGenToApply; rbsGenToBackup >= m_lRBSMaxGenToApply; --rbsGenToBackup )
+    for ( LONG rbsGenToBackup = m_lRBSMaxGenToApply; rbsGenToBackup >= m_lRBSMinGenToApply; --rbsGenToBackup )
     {
         if ( m_fRevertCancelled )
         {

--- a/dev/ese/src/ese/revertsnapshot.cxx
+++ b/dev/ese/src/ese/revertsnapshot.cxx
@@ -4553,6 +4553,10 @@ ERR CRBSDatabaseRevertContext::ErrAddRootPageRecord( BOOL fDeleteOperation, PGNO
     if ( m_rgrootpagerec == NULL )
     {
         m_rgrootpagerec = new CArray< CRootPageRecord >( 32 );
+        if ( m_rgrootpagerec == NULL )
+        {
+            return ErrERRCheck( JET_errOutOfMemory );
+        }
     }
 
     errArray = m_rgrootpagerec->ErrSetEntry( m_rgrootpagerec->Size(), rootpagerec );
@@ -4604,6 +4608,10 @@ ERR CRBSDatabaseRevertContext::ErrCapturePageFDPDeleteState( const LONG lRBSGen,
 
     CArray< CPageFDPDeleteState >* rgpagefdpdeletestate = new CArray< CPageFDPDeleteState >();
     PagesFDPDeleteState            pagesFDPDeleteState;
+    if ( rgpagefdpdeletestate == NULL )
+    {
+        Error( ErrERRCheck( JET_errOutOfMemory ) );
+    }
     errArray = rgpagefdpdeletestate->ErrSetCapacity( cpgRootMove );
 
     if ( errArray != CArray< CPageFDPDeleteState >::ERR::errSuccess )
@@ -4786,6 +4794,10 @@ ERR CRBSDatabaseRevertContext::ErrRBSInitRootPageDeleteState( const LONG lRBSGen
     }
 
     rgpagefdpdeletestate = new CArray< CPageFDPDeleteState >();
+    if ( rgpagefdpdeletestate == NULL )
+    {
+        Error( ErrERRCheck( JET_errOutOfMemory ) );
+    }
     errArray = rgpagefdpdeletestate->ErrLoadEntries( pagesFDPDeleteState->m_rgbPageFDPDeleteState, pagesFDPDeleteState->le_cPagesCaptured * sizeof( CPageFDPDeleteState ) );
 
     if ( errArray != CArray< CPageFDPDeleteState >::ERR::errSuccess )
@@ -4922,6 +4934,7 @@ ERR CRBSDatabaseRevertContext::ErrRBSApplyRootPageRecords( const USHORT cbDbPage
 
                     // Allocate memory for storing src page data.
                     pvPage = PvOSMemoryPageAlloc( cbDbPageSize, NULL );
+                    Alloc( pvPage );
 
                     // Set it on the source pages since after the revert the page would have been on the src of the move.
                     Call( ErrAddPage( pvPage, rootpagerec.PgnoSrc(), fTrue, fFalse, fTrue, fTrue, cbDbPageSize, &fPageAddedToCache ) );
@@ -4930,6 +4943,13 @@ ERR CRBSDatabaseRevertContext::ErrRBSApplyRootPageRecords( const USHORT cbDbPage
                 {
                     *pcpgRootPageCreateMoves = *pcpgRootPageCreateMoves + 1;
                 }
+            }
+            else
+            {
+                //  the destination page's FDP-delete flag is not set, so we do not add
+                //  this page image to the revert context; free the buffer we allocated.
+                OSMemoryPageFree( pvPage );
+                pvPage = NULL;
             }
         }
 

--- a/dev/ese/src/ese/space.cxx
+++ b/dev/ese/src/ese/space.cxx
@@ -14623,15 +14623,17 @@ LOCAL ERR ErrSPIAddExtentInfo(
     if ( *pcextMac >= *pcextMax )
     {
         Assert( *pcextMac == *pcextMax );
-        //  Reallocate ...
-        BTREE_SPACE_EXTENT_INFO * prgextToFree = *pprgext;
+        //  Reallocate into a temporary first, so that an OOM failure here leaves the caller's
+        //  existing array pointer intact (so the caller can still free it) rather than nulling it.
+        BTREE_SPACE_EXTENT_INFO * prgextNew = NULL;
         const ULONG cextNewSize = (*pcextMax) * 2;
-        Alloc( *pprgext = new BTREE_SPACE_EXTENT_INFO[cextNewSize] );
+        Alloc( prgextNew = new BTREE_SPACE_EXTENT_INFO[cextNewSize] );
+        memset( prgextNew, 0, sizeof(BTREE_SPACE_EXTENT_INFO)*cextNewSize );
+        C_ASSERT( sizeof(*prgextNew) == 16 );    // just double checking got level of indirection correct
+        memcpy( prgextNew, *pprgext, *pcextMac * sizeof(*prgextNew) );
+        delete [] *pprgext;
+        *pprgext = prgextNew;
         *pcextMax = cextNewSize;
-        memset( *pprgext, 0, sizeof(BTREE_SPACE_EXTENT_INFO)*(*pcextMax) );
-        C_ASSERT( sizeof(**pprgext) == 16 );    // just double checking got level of indirection correct
-        memcpy( *pprgext, prgextToFree, *pcextMac * sizeof(**pprgext) );
-        delete [] prgextToFree;
     }
     Assert( *pcextMac < *pcextMax );
     AssumePREFAST( *pcextMac < *pcextMax );
@@ -16541,6 +16543,13 @@ ERR ErrSPGetExtentInfo(
     }
 
 HandleError:
+
+    //  on failure the extent array was not handed to the caller (that only happens on success),
+    //  so free it here to avoid leaking it on OOM / mid-enumeration errors.
+    if ( err < JET_errSuccess )
+    {
+        delete [] prgext;
+    }
 
     Expected( pfucbNil != pfucbT ); //  codepaths up to (inclusive) opening the cursor return immediately (i.e., no HandleError cleanup).
 

--- a/dev/ese/src/ese/space.cxx
+++ b/dev/ese/src/ese/space.cxx
@@ -8641,13 +8641,13 @@ ERR ErrSPCaptureSpaceTreePages( FUCB* const pfucbParent, FCB* pfcb, CPG* pcpgSna
     Assert( rgNonLeafPgnos[cpgNonLeafPgnos - 1] == pgnoNull );
 
     cpgno   = cpgLeafPgnos + cpgNonLeafPgnos - 2;
-    rgPgnos = new PGNO[cpgno];
+    Alloc( rgPgnos = new PGNO[cpgno] );
 
     // Ignore the pgnoNull
     memcpy( rgPgnos, rgNonLeafPgnos, ( cpgNonLeafPgnos - 1 ) * sizeof( PGNO ) );
     memcpy( rgPgnos + cpgNonLeafPgnos - 1, rgLeafPgnos, ( cpgLeafPgnos - 1 ) * sizeof( PGNO ) );
 
-    std::sort( rgPgnos, rgPgnos + cpgno - 1, CmpPgno );
+    std::sort( rgPgnos, rgPgnos + cpgno, CmpPgno );
 
     // Find if there is any continuous extent in space tree. Also capture preimage if needed.
     for ( LONG ipg = 0; ipg < cpgno; ++ipg )

--- a/dev/ese/src/ese/sysinit.cxx
+++ b/dev/ese/src/ese/sysinit.cxx
@@ -251,7 +251,7 @@ ERR INST::ErrINSTInit( )
 
     // initialize SCB
 
-    CallJ( ErrSCBInit( this ), TermPIB );
+    CallJ( ErrSCBInit( this ), TermPRL );
 
     CallJ( ErrFUCBInit( this ), TermSCB );
 
@@ -321,6 +321,11 @@ TermFUCB:
 
 TermSCB:
     SCBTerm( this );
+
+TermPRL:
+    //  cancel outstanding patch requests and free the patch request list
+    //  (initialized above by PagePatching::ErrPRLInit)
+    PagePatching::TermInst( this );
 
 TermPIB:
     PIBTerm( this );

--- a/dev/ese/src/ese/sysver.cxx
+++ b/dev/ese/src/ese/sysver.cxx
@@ -193,7 +193,7 @@ ERR ErrGetDesiredVersion( _In_ const INST * const pinstStaging, _In_ JET_ENGINEF
         return JET_errSuccess;
     }
 
-    for ( ULONG i = g_ifmtversLastFeature; i >= 0; i-- )
+    for ( INT i = g_ifmtversLastFeature; i >= 0; i-- )
     {
         if ( g_rgfmtversEngine[i].efv == efvDesired )
         {

--- a/dev/ese/src/inc/ccsr.hxx
+++ b/dev/ese/src/inc/ccsr.hxx
@@ -820,7 +820,7 @@ INLINE VOID CSR::CopyPage( const VOID* pvPage, const ULONG cbPage )
     m_cpage.CopyPage( pvPage, cbPage );
 
     //  set members
-    Assert( m_pgno = m_cpage.PgnoThis() );  // pgno can't change
+    Assert( m_pgno == m_cpage.PgnoThis() );  // pgno can't change
     m_dbtimeSeen = m_cpage.Dbtime();
     m_pagetrimState = pagetrimNormal;
 }

--- a/dev/ese/src/inc/daedef.hxx
+++ b/dev/ese/src/inc/daedef.hxx
@@ -360,7 +360,7 @@ public:
         return fidOld;
     }
 
-    INLINE FID operator+=( const WORD& addend )
+    INLINE FID& operator+=( const WORD& addend )
     {
         m_fidVal = m_fidVal + addend;
         return *this;
@@ -524,7 +524,12 @@ public:
         // all values up to m_fidVal?  For example, if m_fidVal = 0-7, you need
         // 1 byte.  If m_fidVal = 250, you'd need 32 bytes, 1 bit per unique
         // value up to and including 250.
-        return _Omicron( 0, 7, 8 );
+        //
+        // NOTE: The second argument to _Omicron() is a modulo, so it must be 0
+        // here (the identity path) to yield ( m_fidVal + 8 ) / 8.  Passing a
+        // non-zero value (e.g. 7) would incorrectly wrap the count via % and
+        // return a bogus size (e.g. 1 instead of 32 for m_fidVal = 250).
+        return _Omicron( 0, 0, 8 );
     }
     
     INLINE INT IbHash ( ) const
@@ -2208,11 +2213,11 @@ struct INDEXID
 PERSISTED
 struct LOGTIME
 {
-    BYTE    bSeconds;               //  0 - 60
-    BYTE    bMinutes;               //  0 - 60
-    BYTE    bHours;                 //  0 - 24
+    BYTE    bSeconds;               //  0 - 59
+    BYTE    bMinutes;               //  0 - 59
+    BYTE    bHours;                 //  0 - 23
     BYTE    bDay;                   //  1 - 31
-    BYTE    bMonth;                 //  0 - 11
+    BYTE    bMonth;                 //  1 - 12
     BYTE    bYear;                  //  current year - 1900
 
     BYTE    fTimeIsUTC:1;

--- a/dev/ese/src/inc/dataserializer.hxx
+++ b/dev/ese/src/inc/dataserializer.hxx
@@ -351,7 +351,7 @@ private:
     static const INT m_ccolumnsMax = 64;
     const char * m_rgszColumns[m_ccolumnsMax];
     JET_COLTYP m_rgcoltyps[m_ccolumnsMax];
-    unique_ptr<BYTE> m_rgpbData[m_ccolumnsMax];
+    unique_ptr<BYTE[]> m_rgpbData[m_ccolumnsMax];
     size_t m_rgcbData[m_ccolumnsMax];
     INT m_ccolumns;
 

--- a/dev/ese/src/inc/pib.hxx
+++ b/dev/ese/src/inc/pib.hxx
@@ -1108,7 +1108,7 @@ INLINE ERR PIB::ErrSetUserIoPriority( const void* const pvUserFlags, const INT c
     // we've successfully converted all User IoPriority flags into IO QOS flags, so update pib members ...
 
     m_grbitUserIoPriority = *( (JET_GRBIT *) pvUserFlags );
-    m_qosIoPriority |= qosIo;
+    m_qosIoPriority = qosIo;
 
     return JET_errSuccess;
 }

--- a/dev/ese/src/noncore/eseshadow/eseshadow.cxx
+++ b/dev/ese/src/noncore/eseshadow/eseshadow.cxx
@@ -661,6 +661,11 @@ EseShadowCreateShadow(
         // Get the directory name by duping the string, and overwriting the last backslash.
         // I don't think _splitpath works with 'unconventional' paths.
         g_eseRecoveryWriterConfig.m_szDatabasePath = WcsDupNew( g_eseRecoveryWriterConfig.m_szDatabaseFileFullPath );
+        if ( g_eseRecoveryWriterConfig.m_szDatabasePath == NULL )
+        {
+            hr = E_OUTOFMEMORY;
+            goto Cleanup;
+        }
 
         wchar_t* pchLastBackslash = const_cast<wchar_t*>( wcsrchr( g_eseRecoveryWriterConfig.m_szDatabasePath, L'\\' ) );
         if ( pchLastBackslash != NULL )
@@ -797,6 +802,11 @@ EseShadowCreateSimpleShadow(
         // Get the directory name by duping the string, and overwriting the last backslash.
         // I don't think _splitpath works with 'unconventional' paths.
         g_eseRecoveryWriterConfig.m_szDatabasePath = WcsDupNew( g_eseRecoveryWriterConfig.m_szDatabaseFileFullPath );
+        if ( g_eseRecoveryWriterConfig.m_szDatabasePath == NULL )
+        {
+            hr = E_OUTOFMEMORY;
+            goto Cleanup;
+        }
 
         wchar_t* pchLastBackslash = const_cast<wchar_t*>( wcsrchr( g_eseRecoveryWriterConfig.m_szDatabasePath, L'\\' ) );
         if ( pchLastBackslash != NULL )

--- a/dev/ese/src/noncore/eseshadow/esewriter.cxx
+++ b/dev/ese/src/noncore/eseshadow/esewriter.cxx
@@ -413,7 +413,7 @@ EseRecoveryWriter::OnPostSnapshot(
     if ( g_eseRecoveryWriterConfig.m_szSystemDirectory == NULL )
     {
         // If the system path wasn't specified, then copy the log full path.
-        StringCchCopyW( szSystemPath, _countof( szLogPath ), szLogPath );
+        StringCchCopyW( szSystemPath, _countof( szSystemPath ), szLogPath );
     }
     else
     {

--- a/dev/ese/src/noncore/interop/jetinterop.cpp
+++ b/dev/ese/src/noncore/interop/jetinterop.cpp
@@ -5959,7 +5959,7 @@ namespace Isam
             _TCHAR * _szName = 0;
             ::JET_TABLEID _tableid;
 
-            tableid = *(new MJET_TABLEID());
+            tableid = MJET_TABLEID();
             try
             {
                 _szName = GetUnmanagedString( name );

--- a/dev/ese/src/os/blockcache/_hashedlrukcachechunk.hxx
+++ b/dev/ese/src/os/blockcache/_hashedlrukcachechunk.hxx
@@ -222,7 +222,7 @@ INLINE ERR CCachedBlockChunk::ErrValidate( _In_ const QWORD ib, _In_ const Cache
     //
     //  NOTE:  the lost write may be in the flush map.  in that case its write count will be behind
 
-    if ( cbwc != cbwcUnknown && ( !fUninit && m_le_cbwc != cbwc ) || ( fUninit && cbwc != cbwcNeverWritten ) )
+    if ( cbwc != cbwcUnknown && ( ( !fUninit && m_le_cbwc != cbwc ) || ( fUninit && cbwc != cbwcNeverWritten ) ) )
     {
         Error( ErrERRCheck( JET_errReadLostFlushVerifyFailure ) );
     }

--- a/dev/ese/src/os/edbg.cxx
+++ b/dev/ese/src/os/edbg.cxx
@@ -1603,6 +1603,10 @@ public:
             {
                 free( rgcNewNotes );
             }
+            if ( szNewNote )
+            {
+                free( szNewNote );
+            }
             dprintf( "Out of memory, couldn't defer print warning note: %s\n", szWarningMessage );
             return;
         }

--- a/dev/ese/src/os/norm.cxx
+++ b/dev/ese/src/os/norm.cxx
@@ -102,6 +102,8 @@ LOCAL ERR ErrNORMGetLcidInfo( const LCID lcid, const LCTYPE lctype, __deref_out 
         Assert( 0 == cbT || cbT == cbNeeded );
         if ( 0 == cbT )
         {
+            delete[] *psz;
+            *psz = NULL;
             Call( ErrERRCheck( JET_errInternalError ) );
         }
     }
@@ -127,6 +129,8 @@ LOCAL ERR ErrNORMGetLocaleNameInfo( PCWSTR wszLocaleName, const LCTYPE lctype, _
         Assert( 0 == cbT || cbT == cbNeeded );
         if ( 0 == cbT )
         {
+            delete[] *psz;
+            *psz = NULL;
             Call( ErrERRCheck( JET_errInternalError ) );
         }
     }

--- a/dev/ese/src/os/string.cxx
+++ b/dev/ese/src/os/string.cxx
@@ -701,7 +701,7 @@ ERR ErrOSSTRAsciiToUnicodeM( _In_ PCSTR const szzMultiIn,
         }
         CallR( err );
 
-        szCurrent += LOSStrLengthA( szCurrent );
+        szCurrent += LOSStrLengthA( szCurrent ) + 1;
         if ( cchMaxCurrent > cchCurrent )
         {
             cchMaxCurrent -= cchCurrent;

--- a/dev/ese/src/os/task.cxx
+++ b/dev/ese/src/os/task.cxx
@@ -73,6 +73,7 @@ ERR CTaskManager::ErrTMInit(    const ULONG                     cThread,
     //  allocate THREAD handles
 
     m_cThread = 0;
+    m_cThreadMax = cThread;
     Alloc( m_rgThreadContext = new THREADCONTEXT[cThread] );
     memset( m_rgThreadContext, 0, sizeof( THREADCONTEXT ) * cThread );
 
@@ -98,7 +99,6 @@ ERR CTaskManager::ErrTMInit(    const ULONG                     cThread,
     }
 
     Assert( cThread < 1000 );
-    m_cThreadMax = cThread;
 
     //  prepare the thread context
 
@@ -144,6 +144,7 @@ VOID CTaskManager::TMTerm()
 
     m_critActivateThread.Enter();
     m_cTasksThreshold   = 0xffffffff;
+    const ULONG cThreadNodeMax = m_cThreadMax;
     m_cThreadMax        = 0;
     m_critActivateThread.Leave();
 
@@ -246,7 +247,7 @@ VOID CTaskManager::TMTerm()
 
     if ( m_rgpTaskNode )
     {
-        for ( iThread = 0; iThread < m_cThread; iThread++ )
+        for ( iThread = 0; iThread < cThreadNodeMax; iThread++ )
         {
             delete m_rgpTaskNode[iThread];
         }

--- a/dev/ese/src/sync/sync.cxx
+++ b/dev/ese/src/sync/sync.cxx
@@ -6100,7 +6100,7 @@ static void OSSYNCAPI OSSyncICleanup()
         g_piprintfPerfData = NULL;
     }
 
-    if ( NULL != g_piprintfPerfData )
+    if ( NULL != g_pfprintfPerfData )
     {
         ((CFPrintF*)g_pfprintfPerfData)->~CFPrintF();
         LocalFree( g_pfprintfPerfData );

--- a/test/ese/src/bstf/BstfUnitTest/BstfUnitRunner.cxx
+++ b/test/ese/src/bstf/BstfUnitTest/BstfUnitRunner.cxx
@@ -234,6 +234,7 @@ static ERR ErrRunSelectedTests( const char * szTestSpec )
     if ( fSuffixMatch )
         {
         szTestSpec++;
+        cchTestSpec--;
         }
 
     ULONG cTestsRun = 0;
@@ -247,7 +248,7 @@ static ERR ErrRunSelectedTests( const char * szTestSpec )
                 ( 0 == _strnicmp( szTestSpec, punittest->SzName(), cchTestSpec ) ) ) ||
             ( fSuffixMatch && 
                 ( cchCurrTestName >= cchTestSpec ) && 
-                ( 0 == _stricmp( szTestSpec, &(punittest->SzName()[ cchCurrTestName - cchTestSpec + 1 ]) ) ) ) )
+                ( 0 == _stricmp( szTestSpec, &(punittest->SzName()[ cchCurrTestName - cchTestSpec ]) ) ) ) )
             {
             TestCall( ErrRunTest( punittest ) );
             cTestsRun++;

--- a/test/ese/src/devlibtest/cclayer/cclayerunit/CcTypesSuite.cxx
+++ b/test/ese/src/devlibtest/cclayer/cclayerunit/CcTypesSuite.cxx
@@ -386,7 +386,7 @@ ERR CcBasicTypesAreRightSizes::ErrTest()
     else
     {
         const QWORD cbPointer = 4;
-        printf( "\t\tDetected 64-bit platform, testing expected variant sized type against %d bytes.\n", cbPointer );
+        printf( "\t\tDetected 32-bit platform, testing expected variant sized type against %d bytes.\n", cbPointer );
         TestCheck( sizeof(UNSIGNED_PTR) == cbPointer );
         TestCheck( sizeof(SIGNED_PTR) == cbPointer );
         TestCheck( sizeof(size_t) == cbPointer );

--- a/test/ese/src/devlibtest/collection/collectionunit/queuelist.cxx
+++ b/test/ese/src/devlibtest/collection/collectionunit/queuelist.cxx
@@ -91,7 +91,7 @@ ERR SimpleQueueListTest::ErrTest()
     TestCheck( (void*)0xF0BAAD0D != pdata[2] );
 
     TestCheck( pHeadCtorTest->FEmpty() );
-    TestCheck( 0 == Queue.CElements() );
+    TestCheck( 0 == pHeadCtorTest->CElements() );
     TestCheck( NULL == pHeadCtorTest->RemovePrevMost( OffsetOf( RandomStruct, pNext ) ) );
 
     //  test single element insertion, removal, etc

--- a/test/ese/src/devlibtest/errdata/errvalidator/errvalidator.cxx
+++ b/test/ese/src/devlibtest/errdata/errvalidator/errvalidator.cxx
@@ -224,6 +224,7 @@ JET_ERR ErrCheckErrDataErrorsAreInOrder( _In_ const INT cerr )
         if ( abs( perrdataPre->errOrdinal ) >= abs( perrdataPost->errOrdinal ) )
         {
             wprintf( L"\n\tSome errors are not in pre-sorted order ... %d !< %d\n", perrdataPre->errOrdinal, perrdataPost->errOrdinal );
+            return errCodeInconsistency;
         }
     }
 

--- a/test/ese/src/devlibtest/oslayer/oslayerunit/pathtest.cxx
+++ b/test/ese/src/devlibtest/oslayer/oslayerunit/pathtest.cxx
@@ -222,7 +222,7 @@ ERR TestSimpleWszPathFileNameParseFunctionSuite::ErrTest()
     WCHAR * wszFumBar = L"C:\\users\\TheHistorian\\FumBar.edb";
     const WCHAR * wszFumBarFn = pfsapi->WszPathFileName( wszFumBar );
     OSTestCheck( ( (QWORD)wszFumBarFn > (QWORD)wszFumBar ) &&
-                    ( (QWORD)wszFumBarFn < ( ((QWORD)wszFumBarFn) + ( LOSStrLengthW(wszFumBar) * sizeof(WCHAR) ) ) ) );
+                    ( (QWORD)wszFumBarFn < ( ((QWORD)wszFumBar) + ( LOSStrLengthW(wszFumBar) * sizeof(WCHAR) ) ) ) );
     OSTestCheck( 0 == LOSStrCompareW( L"FumBar.edb", wszFumBarFn ) ); // oh and should've worked!
 
 HandleError:

--- a/test/ese/src/devlibtest/stat/statunit/segmentedhisto.cxx
+++ b/test/ese/src/devlibtest/stat/statunit/segmentedhisto.cxx
@@ -223,7 +223,7 @@ ERR SegmentedHistogramTest::ErrTest()
 
     BYTE rgHisto2[CbCSegmentedHistogram( rgThreeCoveringSegments )];
 
-    pSHS = new (rgHisto) CSegmentedHistogram( rgThreeCoveringSegments, _countof( rgThreeCoveringSegments ), rgHisto2, sizeof(rgHisto2) );
+    pSHS = new (rgHisto2) CSegmentedHistogram( rgThreeCoveringSegments, _countof( rgThreeCoveringSegments ), rgHisto2, sizeof(rgHisto2) );
 
     CallTest( pSHS->ErrAddSample( 0 ) );
     for ( ULONG i = 0; i < 30; i++ )

--- a/test/ese/src/devlibtest/sync/syncunit/atomics.cxx
+++ b/test/ese/src/devlibtest/sync/syncunit/atomics.cxx
@@ -61,7 +61,7 @@ ERR SyncPerformsFAtomicIncrementMaxOnDword::ErrTest()
     TestCheck( fFalse == FAtomicIncrementMax( &dw, &dwI, 4 ) );
     TestCheck( dwI == 3 );
     TestCheck( fFalse == FAtomicIncrementMax( &dw, &dwI, 4 ) );
-    TestCheck( dwI == 3 )
+    TestCheck( dwI == 3 );
 
     dw = 0x7ffffffe;
     TestCheck( fTrue == FAtomicIncrementMax( &dw, &dwI, 0x80000002 ) );

--- a/test/ese/src/devlibtest/sync/syncunit/meteredsection.cxx
+++ b/test/ese/src/devlibtest/sync/syncunit/meteredsection.cxx
@@ -283,7 +283,7 @@ ERR CMeteredSectionConcurrentBashTest::ErrTest()
     g_cbashphase = 1;
 
     C_ASSERT( _countof(g_rgtbMscb) == 3 );  //  too lazy
-    while( g_rgtbMscb[0].cUnderflowNegTwo == 0 || g_rgtbMscb[0].cUnderflowNegTwo == 0 || g_rgtbMscb[0].cUnderflowNegTwo == 0 )
+    while( g_rgtbMscb[0].cUnderflowNegTwo == 0 || g_rgtbMscb[1].cUnderflowNegTwo == 0 || g_rgtbMscb[2].cUnderflowNegTwo == 0 )
     {
         Sleep( g_tickPhaseWait );
     }
@@ -308,11 +308,11 @@ ERR CMeteredSectionConcurrentBashTest::ErrTest()
     ULONG ithread = 0;
     while( g_rgtbMscb[ithread].cbashphase != g_cbasephaseDone || ithread++ < _countof(g_rgtbMscb) )
     {
-        wprintf( L"\t\tGot quit of [%d] .. (%#x)\n", ithread, g_rgtbMscb[ithread].cbashphase );
         if ( ithread >= _countof(g_rgtbMscb) )
         {
             break;
         }
+        wprintf( L"\t\tGot quit of [%d] .. (%#x)\n", ithread, g_rgtbMscb[ithread].cbashphase );
         Sleep( g_tickPhaseWait );
     }
 


### PR DESCRIPTION
## Summary

A set of small, independent correctness fixes found while reviewing the engine, OS layer, published headers, and unit tests. Each change is a localized defect (memory safety, a wrong operator/variable, a resource leak on an error path, or an ineffective test) with no intended behavior change beyond the fix. They are grouped here for convenience; please take whichever subset you like and I can split into smaller PRs on request.

## Highlights

**Memory safety / crashes**
- `ese/sysver.cxx` `ErrLGFindFmtVersFromEfv`: `for ( ULONG i = ...; i >= 0; i-- )` never terminates for an unsigned counter and reads out of bounds on the not-found path (two sibling loops already use `INT`).
- `ese/rec.cxx` `ErrRECIMakeKey`: an array allocated with `new[]` was freed with scalar `delete`; also an `&&` that should be `||` guarding a `rgStartColumns[0]` dereference.
- `ese/space.cxx` `ErrSPCaptureSpaceTreePages`: unchecked array allocation + a `std::sort` off-by-one that left the last element unsorted.
- `ese/dbscan.cxx`, `ese/dataserializer.*`: `unique_ptr<T>` owning `new T[]` (scalar delete of an array) -> `unique_ptr<T[]>`, plus a missing null-check before `memcpy`.

**Resource leaks / error paths**
- `ese/revertsnapshot.cxx`, `ese/rbsdump.cxx`, `os/norm.cxx`, `os/edbg.cxx`, `noncore/eseshadow/*`, `noncore/interop/jetinterop.cpp`, `os/task.cxx`.

**Logic**
- `inc/pib.hxx` `ErrSetUserIoPriority`: `|=` -> `=` so the QOS IO priority can be lowered again across calls.
- `published/inc/stat.hxx`: off-by-one (`> 1` -> `> 0`) in the monotonicity guard of both `ErrGetSampleHits` implementations.
- `os/string.cxx` `ErrOSSTRAsciiToUnicodeM`: advance past the NUL so multi-strings beyond the first substring are converted.
- `_log/logwrite.cxx`, `inc/ccsr.hxx`: `=` -> `==` in asserts; `_log/rstmap.cxx`: use the inner-loop index; `os/blockcache/_hashedlrukcachechunk.hxx`: operator precedence; `sync/sync.cxx`: correct perf-data pointer in term; `_xpress9/Xpress9DecLz77.c`: misplaced SET_ERROR arg.

**Tests** (`ese/*_test.cxx`, `test/ese/...`)
- Wrong-variable / tautological assertions, a `sizeof(pointer)`, an out-of-bounds read, a missing `return` on a detected inconsistency, a placement-new buffer mismatch, and a wildcard suffix-match fix.

## Notes
- 33 files changed; each change is small and self-contained.
- Every candidate was verified against surrounding code; suspected-but-intentional patterns were deliberately left unchanged.
- Validated with editor/language-service diagnostics only (no full build here) - please run through CI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/Extensible-Storage-Engine/pull/60)